### PR TITLE
Rename from repository-api to sdr-api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
       IMAGE_NAME: suldlss/sdr-api
     docker:
       - image: circleci/buildpack-deps:stretch
-    
+
 references:
   default_docker_ruby_executor: &default_docker_ruby_executor
     image: circleci/ruby:2.6.4-stretch-node
@@ -43,13 +43,13 @@ jobs:
           command: bundle -v
       - restore_cache:
           keys:
-          - repository-api-bundle-v2-{{ checksum "Gemfile.lock" }}
-          - repository-api-bundle-v2-
+          - sdr-api-bundle-v2-{{ checksum "Gemfile.lock" }}
+          - sdr-api-bundle-v2-
       - run:
           name: Bundle Install
           command: bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
-          key: repository-apis-bundle-v2-{{ checksum "Gemfile.lock" }}
+          key: sdr-apis-bundle-v2-{{ checksum "Gemfile.lock" }}
           paths:
           - vendor/bundle
       - persist_to_workspace:
@@ -64,8 +64,8 @@ jobs:
           at: '~/project'
       - restore_cache:
           keys:
-          - repository-api-bundle-v2-{{ checksum "Gemfile.lock" }}
-          - repository-api-bundle-v2-
+          - sdr-api-bundle-v2-{{ checksum "Gemfile.lock" }}
+          - sdr-api-bundle-v2-
       - run:
           name: Install Bundler
           command: gem install bundler

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![CircleCI](https://circleci.com/gh/sul-dlss/repository-api.svg?style=svg)](https://circleci.com/gh/sul-dlss/repository-api)
-[![Maintainability](https://api.codeclimate.com/v1/badges/9b021ce4e6eb88230b53/maintainability)](https://codeclimate.com/github/sul-dlss/repository-api/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/9b021ce4e6eb88230b53/test_coverage)](https://codeclimate.com/github/sul-dlss/repository-api/test_coverage)
-[![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/repository-api/master/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/repository-api/master/openapi.yml)
+[![CircleCI](https://circleci.com/gh/sul-dlss/sdr-api.svg?style=svg)](https://circleci.com/gh/sul-dlss/sdr-api)
+[![Maintainability](https://api.codeclimate.com/v1/badges/5e17a5a444f2f1014c0000b9/maintainability)](https://codeclimate.com/github/sul-dlss/sdr-api/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/5e17a5a444f2f1014c0000b9/test_coverage)](https://codeclimate.com/github/sul-dlss/sdr-api/test_coverage)
+[![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/sdr-api/master/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/sdr-api/master/openapi.yml)
 [![Docker image](https://images.microbadger.com/badges/image/suldlss/sdr-api.svg)](https://microbadger.com/images/suldlss/sdr-api "Get your own image badge on microbadger.com")
 
-# Repository API
+# Stanford Digital Repository API (SDR-API)
 
 An HTTP API for the SDR.
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ require 'action_view/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module RepositoryApi
+module SdrApi
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 set :application, 'sdr-api'
-set :repo_url, 'https://github.com/sul-dlss/repository-api.git'
+set :repo_url, 'https://github.com/sul-dlss/sdr-api.git'
 
 # Default branch is :master
 ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "repository_api_production"
+  # config.active_job.queue_name_prefix = "sdr_api_production"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>API documentation</title>
+    <title>SDR API documentation</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
 
     <style>
       body {
@@ -14,7 +13,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url='https://raw.githubusercontent.com/sul-dlss/repository-api/master/openapi.yml'></redoc>
+    <redoc spec-url='https://raw.githubusercontent.com/sul-dlss/sdr-api/master/openapi.yml'></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  description: Repository API for Stanford Digital Repository
+  description: Stanford Digital Repository API
   version: 1.0.0
-  title: SDR Repository API
+  title: SDR API
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'


### PR DESCRIPTION
Fixes #56 

## Why was this change made?

Consistent naming makes us happy.

## Was the documentation (README.md, openapi.yml) updated?

Yes.