### PR TITLE
Install sidekiq for background job processing

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -36,6 +36,7 @@ require 'capistrano/passenger'
 require 'capistrano/honeybadger'
 # require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
+require 'capistrano/sidekiq'
 require 'dlss/capistrano'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'dor-services-client'
 gem 'dor-workflow-client'
 gem 'honeybadger'
 gem 'okcomputer'
+gem 'sidekiq', '~> 5.2'
+gem 'sidekiq-statistic'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       dry-validation (~> 1.0, >= 1.0.0)
     confstruct (1.0.2)
       hashie (~> 3.3)
+    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
@@ -240,6 +241,8 @@ GEM
     puma (4.3.1)
       nio4r (~> 2.0)
     rack (2.0.8)
+    rack-protection (2.0.8.1)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.2.1)
@@ -273,6 +276,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.1.3)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
@@ -302,6 +306,14 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
+    sidekiq-statistic (1.4.0)
+      sidekiq (>= 5.0)
+      tilt (~> 2.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -323,6 +335,7 @@ GEM
       net-ssh (>= 2.8.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    tilt (2.0.10)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -361,6 +374,8 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rspec
+  sidekiq (~> 5.2)
+  sidekiq-statistic
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,6 +25,10 @@ append :linked_files, 'config/database.yml', 'config/honeybadger.yml', 'config/s
 # Default value for linked_dirs is []
 append :linked_dirs, 'log', 'config/settings', 'vendor/bundle'
 
+# Sidekiq configuration (run three processes)
+# see sidekiq.yml for concurrency and queue settings
+set :sidekiq_processes, 3
+
 # Default value for default_env is {}
 # set :default_env, { path: '/opt/ruby/bin:$PATH' }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,8 +47,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "sdr_api_production"
+  config.active_job.queue_adapter = :sidekiq
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:concurrency: 6
+:queues:
+  - default


### PR DESCRIPTION
## Why was this change made?

So that we can use a queue for background job processing.

## Was the documentation (README.md, openapi.yml) updated?
n/a
