### PR TITLE
Generate contentMetadata.xml for the uploaded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+!/tmp/assembly
+/tmp/assembly/*
+# Used for testing as the staging area:
+!/tmp/assembly/.keep
 
 # Ignore uploaded files in development.
 /storage/*

--- a/Gemfile
+++ b/Gemfile
@@ -18,17 +18,16 @@ gem 'pg'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+gem 'assembly-objectfile'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client'
 gem 'dor-workflow-client'
+gem 'druid-tools'
 gem 'honeybadger'
 gem 'okcomputer'
 gem 'sidekiq', '~> 5.2'
 gem 'sidekiq-statistic'
-
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    assembly-objectfile (1.8.3)
+      mime-types (> 3)
+      mini_exiftool
+      nokogiri
     ast (2.4.0)
     bcrypt (3.1.13)
     bootsnap (1.4.5)
@@ -214,7 +218,11 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     mimemagic (0.3.3)
+    mini_exiftool (2.10.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -355,6 +363,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  assembly-objectfile
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
@@ -366,6 +375,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services-client
   dor-workflow-client
+  druid-tools
   factory_bot_rails
   honeybadger
   jbuilder (~> 2.7)

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -15,7 +15,10 @@ class ResourcesController < ApplicationController
     end
 
     result = BackgroundJobResult.create
-    IngestJob.perform_later(druid: response[:pid], background_job_result: result)
+
+    IngestJob.perform_later(druid: response[:pid],
+                            filesets: params[:structural].to_unsafe_h.fetch(:hasMember),
+                            background_job_result: result)
 
     render json: { druid: response[:pid] },
            location: result,

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -4,11 +4,20 @@
 class IngestJob < ApplicationJob
   queue_as :default
 
-  def perform(druid:, background_job_result:)
+  # @param [String] druid
+  # @param [Array<Hash>] filesets the data for creating the structure
+  # @param [BackgroundJobResult] background_job_result
+  def perform(druid:, filesets:, background_job_result:)
     background_job_result.processing!
 
-    # TODO: generate contentMetadata.xml
-    # TODO: ship files
+    dir = StagingDirectory.new(druid: druid, staging_location: Settings.staging_location)
+
+    file_names = copy_files_to_staging(dir, filesets)
+
+    # generate contentMetadata.xml
+    xml = ContentMetadataGenerator.generate(file_names: file_names, druid: druid)
+    dir.write_file('contentMetadata.xml', xml)
+
     workflow_client.create_workflow_by_name(druid, 'accessionWF')
   ensure
     background_job_result.complete!
@@ -20,5 +29,24 @@ class IngestJob < ApplicationJob
     Dor::Workflow::Client.new(url: Settings.workflow.url,
                               logger: Rails.logger,
                               timeout: 60)
+  end
+
+  # Copy files to the staging directory from ActiveStorage for the assembly workflow
+  # @return [Array<String>] a list of full paths to the files that were copied
+  def copy_files_to_staging(dir, filesets)
+    files(filesets).each do |blob|
+      dir.copy_file(ActiveStorage::Blob.service.path_for(blob.key), blob.filename.to_s)
+    end
+    filesets.map { |fs| File.join(dir.content_dir, fs['label']) }
+  end
+
+  # @return [Array<ActiveStorage::Blob>] Given a list of filesets, return the corresponding blob objects
+  def files(filesets)
+    signed_ids = filesets.map { |fs| fs.fetch('structural').fetch('hasMember').first }
+
+    file_ids = signed_ids.map { |signed_id| ActiveStorage.verifier.verified(signed_id, purpose: :blob_id) }
+
+    # This can raise ActiveRecord::RecordNotFound if one or more of the files don't exist
+    ActiveStorage::Blob.find(file_ids)
   end
 end

--- a/app/services/content_metadata_generator.rb
+++ b/app/services/content_metadata_generator.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Builds the contentMetadata xml
+class ContentMetadataGenerator
+  # @param [String] druid the object identifier
+  # @param [Array<String>] file_names a list of full paths to the files
+  def self.generate(druid:, file_names:)
+    new(file_names: file_names, druid: druid).generate
+  end
+
+  def initialize(file_names:, druid:)
+    @file_names = file_names
+    @druid = druid
+  end
+
+  def generate
+    Assembly::ContentMetadata.create_content_metadata(cm_params)
+  end
+
+  private
+
+  attr_reader :file_names, :druid
+
+  def cm_params
+    {
+      druid: druid,
+      objects: object_files,
+      file_attributes: file_attributes,
+      add_file_attributes: true,
+      add_exif: false,
+      bundle: :filename,
+      style: :simple_book
+    }
+  end
+
+  def object_files
+    file_names.map { |file_name| Assembly::ObjectFile.new(file_name) }
+  end
+
+  # default publish/preserve/shelve attributes by mimetype
+  #
+  # CAUTION: this is an approach that will probably only work for the GoogleBooks
+  # work cycle because it does not publish or shelve .xml or .md5 files. We
+  # should in the future get this data from the structural metadata itself (e.g. filesets).
+  # rubocop:disable  Metrics/MethodLength
+  def file_attributes
+    {
+      'image/jp2' => {
+        publish: 'yes',
+        shelve: 'yes',
+        preserve: 'yes'
+      },
+      'image/tiff' => {
+        publish: 'no',
+        shelve: 'no',
+        preserve: 'yes'
+      },
+      'application/xml' => {
+        publish: 'no',
+        shelve: 'no',
+        preserve: 'yes'
+      },
+      'default' => {
+        publish: 'no',
+        shelve: 'no',
+        preserve: 'yes'
+      }
+    }
+  end
+  # rubocop:enable  Metrics/MethodLength
+end

--- a/app/services/staging_directory.rb
+++ b/app/services/staging_directory.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# This represents the staging directory where we place files so the assembly
+# robot can access them
+class StagingDirectory
+  def initialize(druid:, staging_location:)
+    @druid = druid
+    @druid_tree_folder = DruidTools::Druid.new(druid, staging_location).path
+    @content_dir = File.join(@druid_tree_folder, 'content')
+    @metadata_dir = File.join(@druid_tree_folder, 'metadata')
+  end
+
+  def write_file(filename, content)
+    ensure_directory_exists!
+    File.open(File.join(metadata_dir, filename), 'w') do |f|
+      f.write content
+    end
+  end
+
+  def copy_file(source, dest)
+    ensure_directory_exists!
+    FileUtils.cp source, File.join(content_dir, dest)
+  end
+
+  attr_reader :content_dir, :metadata_dir
+
+  private
+
+  def ensure_directory_exists!
+    FileUtils.mkdir_p content_dir
+    FileUtils.mkdir_p metadata_dir
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,6 @@ dor_services:
 
 workflow:
   url: 'http://localhost:3001'
+
+
+staging_location: '/dor/assembly'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,1 @@
+staging_location: 'tmp/assembly'

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -3,18 +3,45 @@
 require 'rails_helper'
 
 RSpec.describe IngestJob, type: :job do
-  subject(:run) { described_class.perform_now(druid: druid, background_job_result: result) }
+  subject(:run) do
+    described_class.perform_now(druid: druid, filesets: filesets, background_job_result: result)
+  end
 
   let(:result) { create(:background_job_result) }
   let(:druid) { 'druid:bc123de5678' }
   let(:client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: true) }
+  let(:blob) do
+    ActiveStorage::Blob.create!(key: 'tozuehlw6e8du20vn1xfzmiifyok',
+                                filename: 'file2.txt', byte_size: 10, checksum: 'fffff')
+  end
+  let(:file_id) do
+    ActiveStorage.verifier.generate(blob.id, purpose: :blob_id)
+  end
+
+  let(:filesets) do
+    [
+      {
+        'type' => 'http://cocina.sul.stanford.edu/models/fileset.jsonld',
+        'label' => 'file2.txt',
+        'structural' => { 'hasMember' => [file_id] }
+      }
+    ]
+  end
+  let(:assembly_dir) { 'tmp/assembly/bc/123/de/5678/bc123de5678' }
 
   before do
+    FileUtils.rm_r('tmp/assembly/bc') if File.exist?('tmp/assembly/bc')
+    FileUtils.mkdir_p('tmp/storage/to/zu')
+    File.open('tmp/storage/to/zu/tozuehlw6e8du20vn1xfzmiifyok', 'w') do |f|
+      f.write 'HELLO'
+    end
     allow(Dor::Workflow::Client).to receive(:new).and_return(client)
   end
 
   it 'creates a workflow' do
     run
+    expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
+    expect(File).to exist("#{assembly_dir}/metadata/contentMetadata.xml")
     expect(client).to have_received(:create_workflow_by_name).with(druid, 'accessionWF')
     expect(result).to be_complete
   end

--- a/spec/requests/create_resource_spec.rb
+++ b/spec/requests/create_resource_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe 'Create a resource' do
 
       stub_request(:post, 'http://localhost:3001/objects/druid:abc123/workflows/accessionWF?lane-id=default')
         .to_return(status: 200, body: '', headers: {})
+
+      allow(IngestJob).to receive(:perform_later)
     end
 
     it 'Registers the resource and kicks off accessionWF' do
@@ -59,6 +61,7 @@ RSpec.describe 'Create a resource' do
 
       expect(JSON.parse(response.body)['druid']).to be_present
       expect(response).to be_created
+      expect(IngestJob).to have_received(:perform_later)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

So that the assembly WF has the required prerequisites.
Fixes #54

## Was the documentation (README.md, openapi.yml) updated?

n/a