### PR TITLE
add storage folder as a linked shared directory in capistrano

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ set :deploy_to, '/opt/app/sdr/sdr-api'
 append :linked_files, 'config/database.yml', 'config/honeybadger.yml', 'config/secrets.yml'
 
 # Default value for linked_dirs is []
-append :linked_dirs, 'log', 'config/settings', 'vendor/bundle'
+append :linked_dirs, 'log', 'config/settings', 'vendor/bundle', 'storage'
 
 # Sidekiq configuration (run three processes)
 # see sidekiq.yml for concurrency and queue settings


### PR DESCRIPTION
## Why was this change made?

To fix #79 

After making this change, I believe we just need to SSH into the server and move the current storage folder into the shared location, and then do a deploy to get the symlink set up:

```
cap stage ssh
mv ~/sdr-api/current/storage ~/sdr-api/shared/storage
exit
cap stage deploy
```

## Was the documentation (README.md, openapi.yml) updated?

