### PR TITLE
Correct typo in deposit type enum

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -206,7 +206,7 @@ components:
           enum:
             - 'http://cocina.sul.stanford.edu/models/object.jsonld'
             - 'http://cocina.sul.stanford.edu/models/3d.jsonld'
-            - 'http://cocina.sul.stanford.edu/models/agreement.jsonl'
+            - 'http://cocina.sul.stanford.edu/models/agreement.jsonld'
             - 'http://cocina.sul.stanford.edu/models/book.jsonld'
             - 'http://cocina.sul.stanford.edu/models/document.jsonld'
             - 'http://cocina.sul.stanford.edu/models/geo.jsonld'


### PR DESCRIPTION
## Why was this change made?

To correct our documentation.


## Was the documentation (README.md, openapi.yml) updated?

in fact, yes.