### PR TITLE
Run the assembly workflow, before the accessionWF

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -18,7 +18,7 @@ class IngestJob < ApplicationJob
     xml = ContentMetadataGenerator.generate(file_names: file_names, druid: druid)
     dir.write_file('contentMetadata.xml', xml)
 
-    workflow_client.create_workflow_by_name(druid, 'accessionWF')
+    workflow_client.create_workflow_by_name(druid, 'assemblyWF')
   ensure
     background_job_result.complete!
   end

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe IngestJob, type: :job do
     run
     expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
     expect(File).to exist("#{assembly_dir}/metadata/contentMetadata.xml")
-    expect(client).to have_received(:create_workflow_by_name).with(druid, 'accessionWF')
+    expect(client).to have_received(:create_workflow_by_name).with(druid, 'assemblyWF')
     expect(result).to be_complete
   end
 end


### PR DESCRIPTION
## Why was this change made?

We need to run assembly first to get the files moved to the correct place.

## Was the documentation (README.md, openapi.yml) updated?

n/a