### PR TITLE
Submit a version when creating a workflow

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -18,7 +18,7 @@ class IngestJob < ApplicationJob
     xml = ContentMetadataGenerator.generate(file_names: file_names, druid: druid)
     dir.write_file('contentMetadata.xml', xml)
 
-    workflow_client.create_workflow_by_name(druid, 'assemblyWF')
+    workflow_client.create_workflow_by_name(druid, 'assemblyWF', version: 1)
   ensure
     background_job_result.complete!
   end

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe IngestJob, type: :job do
     run
     expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
     expect(File).to exist("#{assembly_dir}/metadata/contentMetadata.xml")
-    expect(client).to have_received(:create_workflow_by_name).with(druid, 'assemblyWF')
+    expect(client).to have_received(:create_workflow_by_name).with(druid, 'assemblyWF', version: 1)
     expect(result).to be_complete
   end
 end


### PR DESCRIPTION
## Why was this change made?
Because not submitting a version is deprecated


## Was the documentation (README.md, openapi.yml) updated?

N/a