### PR TITLE
Add response for creating an object to openapi.yml.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -127,6 +127,16 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL to retrieve background job results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateObjectResponse'
       requestBody:
         description: The metadata for the object
         required: true
@@ -254,6 +264,11 @@ components:
             - pending
             - processing
             - complete
+    CreateObjectResponse:
+      type: object
+      properties:
+        druid:
+          $ref: '#/components/schemas/Druid'
     ErrorResponse:
       type: object
       properties:


### PR DESCRIPTION
closes #94

## Why was this change made?
Document create object response.

## Was the documentation (README.md, openapi.yml) updated?
Yes
