### PR TITLE
Allow passing md5 and sha1 for files and adds to content metadata.

### DIFF
--- a/app/services/content_metadata_generator.rb
+++ b/app/services/content_metadata_generator.rb
@@ -59,6 +59,9 @@ class ContentMetadataGenerator
       file_node['publish'] = publish_attr(cocina_file)
       file_node['shelve'] = shelve_attr(cocina_file)
       file_node['preserve'] = preserve_attr(cocina_file)
+      cocina_file.fetch('hasMessageDigests', []).each do |message_digest|
+        file_node.add_child(create_checksum_node(message_digest['type'], message_digest['digest']))
+      end
     end
   end
 
@@ -72,6 +75,13 @@ class ContentMetadataGenerator
 
   def preserve_attr(cocina_file)
     cocina_file.fetch('administrative').fetch('sdrPreserve') ? 'yes' : 'no'
+  end
+
+  def create_checksum_node(algorithm, digest)
+    Nokogiri::XML::Node.new('checksum', @xml_doc).tap do |checksum_node|
+      checksum_node['type'] = algorithm
+      checksum_node.content = digest
+    end
   end
 
   # @param [Hash] cocina_fileset the cocina fileset

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22,6 +22,8 @@ CREATE TYPE public.background_job_result_status AS ENUM (
 
 SET default_tablespace = '';
 
+SET default_with_oids = false;
+
 --
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
 --

--- a/openapi.yml
+++ b/openapi.yml
@@ -302,6 +302,10 @@ components:
           type: string
         hasMimeType:
           type: string
+        hasMessageDigests:
+          type: array
+          items:
+            $ref: '#/components/schemas/MessageDigest'
         administrative:
           $ref: '#/components/schemas/FileAdministrative'
         access:
@@ -387,6 +391,22 @@ components:
           example: Searchworks
         release:
           type: boolean
+    MessageDigest:
+      description: The output of the message digest algorithm.
+      type: object
+      properties:
+        type:
+          description: The algorithm that was used
+          type: string
+          enum:
+            - md5
+            - sha1
+        digest:
+          description: The digest value
+          type: string
+      required:
+        - type
+        - digest
     DROStructural:
       type: object
       properties:

--- a/spec/services/content_metadata_generator_spec.rb
+++ b/spec/services/content_metadata_generator_spec.rb
@@ -28,7 +28,18 @@ RSpec.describe ContentMetadataGenerator do
       },
       'access' => {
         'access' => 'dark'
-      }
+      },
+      'hasMessageDigests' => [
+        {
+          'type' => 'sha1',
+          'digest' => 'cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7'
+        },
+        {
+          'type' => 'md5',
+          'digest' => 'e6d52da47a5ade91ae31227b978fb023'
+        }
+
+      ]
     }
   end
 
@@ -100,7 +111,10 @@ RSpec.describe ContentMetadataGenerator do
        <contentMetadata objectId="druid:bc123de5678" type="book">
          <resource id="bc123de5678_1" sequence="1" type="object">
            <label>Object 1</label>
-           <file id="00001.html" preserve="yes" publish="no" shelve="no"/>
+           <file id="00001.html" preserve="yes" publish="no" shelve="no">
+             <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
+             <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
+           </file>
            <file id="00001.jp2" preserve="yes" publish="yes" shelve="yes"/>
          </resource>
          <resource id="bc123de5678_2" sequence="2" type="object">


### PR DESCRIPTION
## Why was this change made?
To allow MD5 to be passed when depositing Google Books.


## Was the documentation (README.md, openapi.yml) updated?
Yes, openapi.yml.