### PR TITLE
Updated instructions for building the docker app image

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ docker-compose up -d db
 ```
 
 ### Build the api container
-
+If `tmp/pids/server.pid` is missing from the root directory of the project, just
+touch that file before building or
+[puma](https://puma.io/) will fail when starting the app.
 ```
 docker-compose build app
 ```


### PR DESCRIPTION
## Why was this change made?
Adds note about the `tmp/pids/server.pid` need to present in order to run `docker-compose up app` command. 


## Was the documentation (README.md, openapi.yml) updated?
Yes
