### PR TITLE
New .keep file to persist directory for docker build of app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .git
 .dockerignore
 .byebug_history
-log/*
-tmp/*
+log
+tmp
+# Required for puma to have a place to put the pid file
+!tmp/pids/.keep
 postgres-data/*

--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,14 @@
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
+/tmp/pids/*
 !/log/.keep
 !/tmp/.keep
 !/tmp/assembly
 /tmp/assembly/*
+!/tmp/pids
+# Required for puma to have a place to put the pid file
+!/tmp/pids/.keep
 # Used for testing as the staging area:
 !/tmp/assembly/.keep
 


### PR DESCRIPTION
## Why was this change made?
Running the app with docker-compose works by persisting the `/tmp/pids/` directory with a `.keep` file for git and docker.


## Was the documentation (README.md, openapi.yml) updated?
n/a
