### PR TITLE
Sets use attribute on file if html file has hOCR element

### DIFF
--- a/app/services/content_metadata_generator.rb
+++ b/app/services/content_metadata_generator.rb
@@ -59,6 +59,7 @@ class ContentMetadataGenerator
       file_node['publish'] = publish_attr(cocina_file)
       file_node['shelve'] = shelve_attr(cocina_file)
       file_node['preserve'] = preserve_attr(cocina_file)
+      ocr?(cocina_file) ? file_node['use'] = 'transcription' : ''
       cocina_file.fetch('hasMessageDigests', []).each do |message_digest|
         file_node.add_child(create_checksum_node(message_digest['type'], message_digest['digest']))
       end
@@ -75,6 +76,17 @@ class ContentMetadataGenerator
 
   def preserve_attr(cocina_file)
     cocina_file.fetch('administrative').fetch('sdrPreserve') ? 'yes' : 'no'
+  end
+
+  def ocr?(cocina_file)
+    if cocina_file.fetch('hasMimeType') == 'text/html'
+      # finds file in @file_names, parses HTML with Nokogiri for hOCR tags to return
+      # true if found
+      file_path = file_names.fetch(cocina_file.fetch('filename'))
+      doc = Nokogiri::HTML(File.open(file_path))
+      return true unless doc.css("meta[@name='ocr-capabilities']").empty?
+    end
+    false
   end
 
   def create_checksum_node(algorithm, digest)

--- a/spec/fixtures/00001.html
+++ b/spec/fixtures/00001.html
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml http://www.w3.org/MarkUp/SCHEMA/xhtml11.xsd"
+ xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>00000004.html</title>
+<meta http-equiv='content-type' content='text/html; charset=utf-8'/>
+<meta http-equiv='content-style-type' content='text/css' />
+<meta name='ocr-capabilities' content='ocr_page ocr_par ocr_block ocrx_block ocrx_word ocrp_lang ocr_line' />
+<meta name='ocr-system' content='ABBYY fre-9.0.0.6953' />
+<meta name='ocr-number-of-pages' content='1' />
+<meta name='ocr-langs' content='unknown' />
+</head>
+<body title="x_wconf 0">
+<div class='ocr_page' title='bbox 0 0 1778 2681;ppageno 4;x_source 9007199259212880-8;ocrp_lang unknown'>
+</div></body>
+</html>

--- a/spec/services/content_metadata_generator_spec.rb
+++ b/spec/services/content_metadata_generator_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe ContentMetadataGenerator do
        <contentMetadata objectId="druid:bc123de5678" type="book">
          <resource id="bc123de5678_1" sequence="1" type="object">
            <label>Object 1</label>
-           <file id="00001.html" preserve="yes" publish="no" shelve="no">
+           <file id="00001.html" preserve="yes" publish="no" shelve="no" use="transcription">
              <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
              <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
            </file>


### PR DESCRIPTION
## Why was this change made?
To set the use attribute in `contentMetadata.mxl` if a file is HTML and has an hOCR meta element.
Closes #45 

## Was the documentation (README.md, openapi.yml) updated?
n/a