### PR TITLE
Remove outdated uploads on a schedule

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -38,6 +38,7 @@ require 'capistrano/honeybadger'
 require 'capistrano/rails/migrations'
 require 'capistrano/sidekiq'
 require 'dlss/capistrano'
+require 'whenever/capistrano'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'pg'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'assembly-objectfile'
-gem 'cocina-models', '~> 0.8.0'
+gem 'cocina-models'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 4.2'
@@ -29,6 +29,7 @@ gem 'honeybadger'
 gem 'okcomputer'
 gem 'sidekiq', '~> 5.2'
 gem 'sidekiq-statistic'
+gem 'whenever', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,8 @@ GEM
     capistrano-sidekiq (1.0.3)
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
-    cocina-models (0.8.0)
+    chronic (0.10.2)
+    cocina-models (0.11.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -124,9 +125,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.2)
-    dor-services-client (4.2.0)
+    dor-services-client (4.4.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.8.0)
+      cocina-models (~> 0.11.0)
       faraday (~> 0.15)
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
@@ -358,6 +359,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     zeitwerk (2.2.2)
 
 PLATFORMS
@@ -371,7 +374,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-sidekiq
-  cocina-models (~> 0.8.0)
+  cocina-models
   committee
   config (~> 2.0)
   dlss-capistrano
@@ -397,6 +400,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   webmock
+  whenever
 
 BUNDLED WITH
    2.1.4

--- a/app/services/direct_uploads_sweeper.rb
+++ b/app/services/direct_uploads_sweeper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Sweep direct uploads per an injected strategy
+class DirectUploadsSweeper
+  # Use a public accessor to allow for interactive injection of the strategy
+  # dependency
+  attr_accessor :strategy
+
+  # @param [#select] strategy a database selection strategy
+  def initialize(strategy: default_selection_strategy)
+    @strategy = strategy
+  end
+
+  # @return void
+  def sweep
+    # NOTE: Prefer `#purge_later` over `#purge` and `#destroy`. `#destroy`
+    #       only deletes database entries, whereas `#purge*` also removes
+    #       files on the filesystem. The purge operation itself may be a slow
+    #       operation, so run it in the background via `#purge_later` per
+    #       https://github.com/rails/rails/blob/v6.0.2.1/activestorage/app/models/active_storage/blob.rb#L224-L245
+    strategy
+      .select
+      .find_each(batch_size: Settings.sdr_api.blob_batch_size, &:purge_later)
+  end
+
+  private
+
+  def default_selection_strategy
+    SelectNoUploadsStrategy
+  end
+end

--- a/app/services/select_no_uploads_strategy.rb
+++ b/app/services/select_no_uploads_strategy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# A strategy class that selects no uploads: a null strategy, if you will. Used
+# by the `DirectUploadsSweeper`
+class SelectNoUploadsStrategy
+  # @return [ActiveRecord::Relation]
+  def self.select
+    new.select
+  end
+
+  # @return [ActiveRecord::Relation]
+  def select
+    active_record_class.none
+  end
+
+  private
+
+  def active_record_class
+    ActiveStorage::Blob
+  end
+end

--- a/app/services/select_outdated_uploads_strategy.rb
+++ b/app/services/select_outdated_uploads_strategy.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# A strategy class that selects uploads older than a given or configured date.
+# Used by the `DirectUploadsSweeper`
+class SelectOutdatedUploadsStrategy
+  # @param [Integer] days_ago an integer representing the number of days before which uploads will be selected
+  # @return [ActiveRecord::Relation]
+  def self.select(days_ago: default_days_ago)
+    new(days_ago: days_ago).select
+  end
+
+  # @return [Integer]
+  def self.default_days_ago
+    Settings.sdr_api.days_after_which_to_remove_uploads
+  end
+
+  attr_reader :days_ago
+
+  # @param [Integer] days_ago an integer representing the number of days ago before which uploads will be selected
+  def initialize(days_ago: default_days_ago)
+    @days_ago = days_ago.days.ago
+  end
+
+  # @return [ActiveRecord::Relation]
+  def select
+    active_record_class.where(
+      active_record_class.arel_table[:created_at].lt(
+        days_ago
+      )
+    )
+  end
+
+  private
+
+  def default_days_ago
+    self.class.default_days_ago
+  end
+
+  def active_record_class
+    ActiveStorage::Blob
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# https://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# Learn more: https://github.com/javan/whenever
+
+every :day do
+  set :output, standard: nil, error: 'log/uploads_sweeper.log'
+  runner 'DirectUploadsSweeper.new(strategy: SelectOutdatedUploadsStrategy).sweep'
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,7 @@
+sdr_api:
+  days_after_which_to_remove_uploads: 7
+  blob_batch_size: 20
+
 dor_services:
   url: 'http://localhost:3003'
   # To generate the token: docker-compose run dor-services-app rake generate_token
@@ -5,6 +9,5 @@ dor_services:
 
 workflow:
   url: 'http://localhost:3001'
-
 
 staging_location: '/dor/assembly'

--- a/spec/factories/active_storage_blobs.rb
+++ b/spec/factories/active_storage_blobs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :active_storage_blob, class: 'ActiveStorage::Blob' do
+    sequence(:key) do |n|
+      "abc123-#{n}"
+    end
+
+    byte_size { 123 }
+    checksum { 'abcdefghijklmnopqrstuvwxyz' }
+    created_at { Time.current }
+    filename { 'file.txt' }
+  end
+end

--- a/spec/services/direct_uploads_sweeper_spec.rb
+++ b/spec/services/direct_uploads_sweeper_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DirectUploadsSweeper do
+  subject(:sweeper) { described_class.new }
+
+  let(:default_strategy) { sweeper.send(:default_selection_strategy) }
+  let(:mock_strategy) { double }
+
+  describe '#initialize' do
+    it 'sets a default selection strategy' do
+      expect(sweeper.strategy).to eq(default_strategy)
+    end
+
+    context 'with `strategy:` keyword argument' do
+      subject(:sweeper) { described_class.new(strategy: mock_strategy) }
+
+      it 'allows injection of a selection strategy' do
+        expect(sweeper.strategy).to eq(mock_strategy)
+      end
+    end
+  end
+
+  describe '#strategy=' do
+    before do
+      sweeper.strategy = mock_strategy
+    end
+
+    it 'allows injection of a selection strategy' do
+      expect(sweeper.strategy).to eq(mock_strategy)
+    end
+  end
+
+  describe '#sweep' do
+    let(:mock_relation) { instance_double(ActiveRecord::Relation, find_each: nil) }
+    let(:mock_strategy) { double(select: mock_relation) } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      # Use mock strategy to test #sweep behavior because it is easier to mock,
+      # and the default selection strategy is tested elsewhere
+      sweeper.strategy = mock_strategy
+    end
+
+    it 'iterates over the selected records and purges them' do
+      sweeper.sweep
+      expect(sweeper.strategy).to have_received(:select).once
+      expect(mock_relation).to have_received(:find_each).with(batch_size: anything, &:purge_later).once
+    end
+  end
+end

--- a/spec/services/select_no_uploads_strategy_spec.rb
+++ b/spec/services/select_no_uploads_strategy_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SelectNoUploadsStrategy do
+  subject(:strategy) { described_class.new }
+
+  describe '.select' do
+    before do
+      allow(described_class).to receive(:new).and_return(mock_instance)
+    end
+
+    let(:mock_instance) { instance_double(described_class, select: nil) }
+
+    it 'invokes #select on a new instance of the class' do
+      described_class.select
+      expect(mock_instance).to have_received(:select).once
+    end
+  end
+
+  describe '#select' do
+    subject(:selection) { strategy.select }
+
+    it { is_expected.to be_kind_of(ActiveRecord::Relation) }
+
+    it 'returns an empty set' do
+      expect(selection.size).to be_zero
+    end
+  end
+end

--- a/spec/services/select_outdated_uploads_strategy_spec.rb
+++ b/spec/services/select_outdated_uploads_strategy_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SelectOutdatedUploadsStrategy do
+  subject(:strategy) { described_class.new }
+
+  describe '.select' do
+    before do
+      allow(described_class).to receive(:new).and_return(mock_instance)
+    end
+
+    let(:mock_instance) { instance_double(described_class, select: nil) }
+
+    it 'invokes #select on a new instance of the class' do
+      described_class.select
+      expect(mock_instance).to have_received(:select).once
+    end
+  end
+
+  describe '#initialize' do
+    subject(:default_days_ago) { strategy.send(:default_days_ago) }
+
+    it 'sets a default days_ago attr' do
+      expect(strategy.days_ago.to_date).to eq(default_days_ago.days.ago.to_date)
+    end
+
+    context 'when injecting a days_ago attr' do
+      let(:strategy) { described_class.new(days_ago: days_ago) }
+      let(:days_ago) { 2 }
+      let(:date_difference) { (Date.today - days_ago.days.ago.to_date).to_i }
+
+      it 'sets the days_ago attr to a normalized time object' do
+        expect(strategy.days_ago.to_date).not_to eq(default_days_ago.days.ago.to_date)
+        expect(date_difference).to eq(days_ago)
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/LetSetup
+  describe '#select' do
+    subject(:selection) { strategy.select }
+
+    let(:old_days_ago1) { 28.days.ago }
+    let(:old_days_ago2) { 14.days.ago }
+    let!(:outdated_upload1) { create(:active_storage_blob, created_at: old_days_ago1) }
+    let!(:outdated_upload2) { create(:active_storage_blob, created_at: old_days_ago2) }
+    let!(:current_upload1) { create(:active_storage_blob) }
+    let!(:current_upload2) { create(:active_storage_blob) }
+    let!(:current_upload3) { create(:active_storage_blob) }
+
+    it { is_expected.to be_kind_of(ActiveRecord::Relation) }
+
+    it 'returns both outdated uploads and none of the current ones' do
+      expect(selection.size).to eq(2)
+      expect(selection).to match_array([outdated_upload1, outdated_upload2])
+    end
+  end
+  # rubocop:enable RSpec/LetSetup
+end


### PR DESCRIPTION
Fixes #97

## Why was this change made?

Includes:
* Add a new sweeper service that selects records to be swept based on an injectable strategy, defaulting to an empty set
* Add a null upload selection strategy and an outdated upload selection strategy
* Sweep uploads every day on a schedule
* Add configuration to allow setting a default "older than" date for determining which uploads to remove and a value to control ActiveRecord batch size for `AS::Blob`s
* Update cocina-models and dor-services-client (opportunistic upgrades)

## Was the documentation (README.md, openapi.yml) updated?

No.
