### PR TITLE
Remove production env instruction from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker-compose up -d app
 ## Create a user
 
 ```
-./bin/rails runner -e production 'User.create!(email: "jcoyne@justincoyne.com", password:  "sekret!")'
+./bin/rails runner 'User.create!(email: "jcoyne@justincoyne.com", password:  "sekret!")'
 ```
 
 ## Authorization
@@ -52,7 +52,7 @@ Log in to get a token by calling:
 ```
 curl -X POST -H 'Content-Type: application/json' \
   -d '{"email":"jcoyne@justincoyne.com","password":"sekret!"}' \
-  https://{hostname}/v1/auth/login
+  http://{hostname}/v1/auth/login
 ```
 
 In subsequent requests, submit the token in the `Authorization` header:


### PR DESCRIPTION
## Why was this change made?

Including the `-e production` parameter in the create user instruction is inaccurate.

## Was the documentation (README.md, openapi.yml) updated?

README