### PR TITLE
Add a registered by tag (like Argo does)

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -32,7 +32,7 @@ class ResourcesController < ApplicationController
     {
       object_type: 'item',
       admin_policy: params[:administrative][:hasAdminPolicy],
-      tag: AdministrativeTags.for(type: params[:type]),
+      tag: AdministrativeTags.for(type: params[:type], user: current_user.email),
       # ':auto' is a special value for the registration service.
       # see https://github.com/sul-dlss/dor-services-app/blob/master/app/services/registration_service.rb#L37
       label: params[:label].presence || ':auto',

--- a/app/services/administrative_tags.rb
+++ b/app/services/administrative_tags.rb
@@ -2,13 +2,13 @@
 
 # Return a list of administrative tags for a given type URI
 class AdministrativeTags
-  def self.for(type:)
+  def self.for(type:, user:)
     case type
     when Cocina::Models::Vocab.book
       # NOTE: For now, we assume all books are LTR until we learn how to discern
       #       otherwise. See related issue:
       #       https://github.com/sul-dlss/google-books/issues/184
-      ['Process : Content Type : Book (ltr)'].freeze
+      ['Process : Content Type : Book (ltr)', "Registered By : #{user}"].freeze
     else
       [].freeze
     end

--- a/spec/requests/create_resource_spec.rb
+++ b/spec/requests/create_resource_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe 'Create a resource' do
         stub_request(:post, 'http://localhost:3003/v1/objects')
           .with(
             body: '{"object_type":"item","admin_policy":"druid:bc123df4567",' \
-                  '"tag":["Process : Content Type : Book (ltr)"],"label":"hello",' \
+                  '"tag":["Process : Content Type : Book (ltr)","Registered By : jcoyne85@stanford.edu"],' \
+                  '"label":"hello",' \
                   '"collection":"druid:fg123hj4567","rights":"default",' \
                   '"metadata_source":"symphony","other_id":"symphony:123456"}',
             headers: {

--- a/spec/services/administrative_tags_spec.rb
+++ b/spec/services/administrative_tags_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe AdministrativeTags do
-  subject(:administrative_tags) { described_class.for(type: type_uri) }
+  subject(:administrative_tags) { described_class.for(type: type_uri, user: 'bergeraj') }
 
   describe '.for' do
     context 'with a book object' do
       let(:type_uri) { Cocina::Models::Vocab.book }
 
-      it { is_expected.to eq(['Process : Content Type : Book (ltr)']) }
+      it { is_expected.to eq(['Process : Content Type : Book (ltr)', 'Registered By : bergeraj']) }
     end
 
     context 'with a non-book object' do


### PR DESCRIPTION
## Why was this change made?

So we can see who is using this service.

## Was the documentation (README.md, openapi.yml) updated?

n/a