### PR TITLE
Fetch mimetype attr from file model and insert in content metadata

### DIFF
--- a/app/services/content_metadata_generator.rb
+++ b/app/services/content_metadata_generator.rb
@@ -56,6 +56,7 @@ class ContentMetadataGenerator
   def create_file_node(id, cocina_file)
     Nokogiri::XML::Node.new('file', @xml_doc).tap do |file_node|
       file_node['id'] = id
+      file_node['mimetype'] = cocina_file.fetch('hasMimeType')
       file_node['publish'] = publish_attr(cocina_file)
       file_node['shelve'] = shelve_attr(cocina_file)
       file_node['preserve'] = preserve_attr(cocina_file)

--- a/spec/services/content_metadata_generator_spec.rb
+++ b/spec/services/content_metadata_generator_spec.rb
@@ -111,16 +111,16 @@ RSpec.describe ContentMetadataGenerator do
        <contentMetadata objectId="druid:bc123de5678" type="book">
          <resource id="bc123de5678_1" sequence="1" type="object">
            <label>Object 1</label>
-           <file id="00001.html" preserve="yes" publish="no" shelve="no">
+           <file id="00001.html" mimetype="text/html" preserve="yes" publish="no" shelve="no">
              <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
              <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
            </file>
-           <file id="00001.jp2" preserve="yes" publish="yes" shelve="yes"/>
+           <file id="00001.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
          </resource>
          <resource id="bc123de5678_2" sequence="2" type="object">
            <label>Object 2</label>
-           <file id="00002.html" preserve="yes" publish="yes" shelve="no"/>
-           <file id="00002.jp2" preserve="yes" publish="yes" shelve="yes"/>
+           <file id="00002.html" mimetype="text/html" preserve="yes" publish="yes" shelve="no"/>
+           <file id="00002.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
          </resource>
        </contentMetadata>'
   end


### PR DESCRIPTION
Fixes #109

## Why was this change made?

To add the needed MIME type attribute to content metadata in SDR.

## Was the documentation (README.md, openapi.yml) updated?


no