### PR TITLE
Aligned the catkey with cocina-models

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -30,19 +30,10 @@ class ResourcesController < ApplicationController
     model_params = params.to_unsafe_h
     model_params[:label] = ':auto' if model_params[:label].nil?
     model_params[:version] = 1 if model_params[:version].nil?
+    # Presently, the create model endpoint in dor-services-app, can't handle filesets,
+    # so, we remove them here and make contentMetadata.xml instead.
     model_params[:structural].delete(:contains)
-    clean_catkey(model_params)
     Cocina::Models::RequestDRO.new(model_params)
-  end
-
-  def clean_catkey(model_params)
-    catkey = model_params[:identification].delete(:catkey)
-    return if catkey.nil?
-
-    model_params[:identification][:catalogLinks] = [{
-      catalog: 'symphony',
-      catalogRecordId: catkey
-    }]
   end
 
   # JSON-API error response. See https://jsonapi.org/

--- a/openapi.yml
+++ b/openapi.yml
@@ -347,6 +347,18 @@ components:
             - pending
             - processing
             - complete
+    CatalogLink:
+      type: object
+      required:
+        - catalog
+        - catalogRecordId
+      properties:
+        catalog:
+          type: string
+          example: symphony
+        catalogRecordId:
+          type: string
+          example: 11403803
     CreateObjectResponse:
       type: object
       properties:
@@ -379,10 +391,11 @@ components:
     Identification:
       type: object
       properties:
-        catkey:
-          description: If catkey is not provded, then label is required.  If catkey is provided, the label will be looked up from Sirsi.
-          type: string
-          example: "4084372"
+        catalogLinks:
+          description: If catalogLink is not provded, then label is required.  If catalogLink is provided, the label will be looked up from Sirsi.
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogLink'
         sourceId:
           type: string
           example: "bib4084372"

--- a/spec/requests/create_resource_spec.rb
+++ b/spec/requests/create_resource_spec.rb
@@ -18,7 +18,12 @@ RSpec.describe 'Create a resource' do
           "hasAdminPolicy":"druid:bc123df4567"
         },
         "identification": {
-          "catkey":"123456",
+          "catalogLinks": [
+              {
+                "catalog":"symphony",
+                "catalogRecordId":"123456"
+              }
+          ],
           "sourceId":"googlebooks:stanford_82323429"
         },
         "structural":{


### PR DESCRIPTION


## Why was this change made?

This is how sdr-client is supplying the catkey since 0.13.0
Fixes #125 

## Was the documentation (README.md, openapi.yml) updated?

yes