### PR TITLE
Adds creating registrationWF when registering.

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -4,13 +4,24 @@ class ResourcesController < ApplicationController
   before_action :authorize_request
 
   # POST /objects
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def create
     begin
       response_cocina_obj = Dor::Services::Client.objects.register(params: cocina_model)
     rescue Dor::Services::Client::UnexpectedResponse => e
       return render build_error('Bad Request', e, '400', :bad_request)
     rescue Dor::Services::Client::ConnectionFailed => e
-      return render build_error('Unable to reach dor-services-app', e, '504', :gateway_timeout)
+      return render build_error('Unable to reach dor-services-app', e, '504',
+                                :gateway_timeout)
+    end
+
+    # Doing this here rather than IngestJob so that have accurate timestamp for milestone.
+    begin
+      workflow_client.create_workflow_by_name(response_cocina_obj.externalIdentifier, 'registrationWF', version: 1)
+    rescue Dor::WorkflowException => e
+      return render build_error('Error creating registrationWF with workflow-service', e, '502',
+                                :bad_gateway)
     end
 
     result = BackgroundJobResult.create
@@ -23,6 +34,8 @@ class ResourcesController < ApplicationController
            location: result,
            status: :created
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   private
 
@@ -51,5 +64,11 @@ class ResourcesController < ApplicationController
       content_type: 'application/vnd.api+json',
       status: status
     }
+  end
+
+  def workflow_client
+    Dor::Workflow::Client.new(url: Settings.workflow.url,
+                              logger: Rails.logger,
+                              timeout: 60)
   end
 end


### PR DESCRIPTION
closes https://github.com/sul-dlss/google-books/issues/315

## Why was this change made?
registrationWF is run to create the registration milestone.

## Was the documentation (README.md, openapi.yml) updated?
No.