### PR TITLE
Return errors from dor-services-app as 502 not 400

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -10,7 +10,7 @@ class ResourcesController < ApplicationController
     begin
       response_cocina_obj = Dor::Services::Client.objects.register(params: cocina_model)
     rescue Dor::Services::Client::UnexpectedResponse => e
-      return render build_error('Bad Request', e, '400', :bad_request)
+      return render build_error('Error registering object with dor-services-app', e, '502', :bad_gateway)
     rescue Dor::Services::Client::ConnectionFailed => e
       return render build_error('Unable to reach dor-services-app', e, '504',
                                 :gateway_timeout)

--- a/openapi.yml
+++ b/openapi.yml
@@ -104,6 +104,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateObjectResponse'
+        '502':
+          description: Bad gateway for DOR or workflow services
+        '504':
+          description: Gateway timeout
       requestBody:
         description: The metadata for the object
         required: true


### PR DESCRIPTION
## Why was this change made?
To return a more accurate error code when call to dor-services-app returns an error.


## Was the documentation (README.md, openapi.yml) updated?
Yes.