### PR TITLE
Add capistrano deployments for prod and qa

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+server 'sdr-api-prod.stanford.edu', user: 'sdr', roles: %w[app db web]
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'
+set :bundle_without, %w[deployment test development].join(' ')

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+server 'sdr-api-qa.stanford.edu', user: 'sdr', roles: %w[app db web]
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'
+set :bundle_without, %w[deployment test development].join(' ')


### PR DESCRIPTION
## Why was this change made?

fixes #126 - adds production and qa deployments in capistrano, both have been completed and shared_configs have been established.

## Was the documentation (README.md, openapi.yml) updated?

N/A
