### PR TITLE
Fix active storage purge

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,4 @@
 :concurrency: 6
 :queues:
   - default
+  - active_storage_purge


### PR DESCRIPTION
## Why was this change made?
Because there were no workers handling active_storage_purge queue.


## Was the documentation (README.md, openapi.yml) updated?
No