### PR TITLE
Enable new rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,11 @@ RSpec/ExampleLength:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true

--- a/app/services/content_metadata_generator.rb
+++ b/app/services/content_metadata_generator.rb
@@ -122,8 +122,8 @@ class ContentMetadataGenerator
 
   # @return [Hash<String,Assembly::ObjectFile>]
   def object_files
-    @object_files ||= file_names.each_with_object({}) do |(short, file_path), out|
-      out[short] = Assembly::ObjectFile.new(file_path)
+    @object_files ||= file_names.transform_values do |file_path|
+      Assembly::ObjectFile.new(file_path)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

So we stop seeing the warning about new cops.

## Was the documentation (README.md, openapi.yml) updated?
n/a


## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
