### PR TITLE
Adds logging of sweeping.

### DIFF
--- a/app/services/direct_uploads_sweeper.rb
+++ b/app/services/direct_uploads_sweeper.rb
@@ -18,9 +18,14 @@ class DirectUploadsSweeper
     #       files on the filesystem. The purge operation itself may be a slow
     #       operation, so run it in the background via `#purge_later` per
     #       https://github.com/rails/rails/blob/v6.0.2.1/activestorage/app/models/active_storage/blob.rb#L224-L245
+    count = 0
     strategy
       .select
-      .find_each(batch_size: Settings.sdr_api.blob_batch_size, &:purge_later)
+      .find_each(batch_size: Settings.sdr_api.blob_batch_size) do |upload|
+      upload.purge_later
+      count += 1
+    end
+    Rails.logger.info("Queued #{count} uploads for purging.")
   end
 
   private

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,6 +12,6 @@
 # Learn more: https://github.com/javan/whenever
 
 every :day do
-  set :output, standard: nil, error: 'log/uploads_sweeper.log'
+  set :output, standard: 'log/uploads_sweeper.log', error: 'log/uploads_sweeper.error.log'
   runner 'DirectUploadsSweeper.new(strategy: SelectOutdatedUploadsStrategy).sweep'
 end


### PR DESCRIPTION
closes #154

## Why was this change made?
So that when troubleshooting, can tell if sweeper ran.

## Was the documentation (README.md, openapi.yml) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Testing in stage.