### PR TITLE
Objects do not have to be in a collection

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -451,8 +451,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileSet'
-      required:
-        - isMemberOf
     FileSetStructural:
       type: object
       properties:


### PR DESCRIPTION
## Why was this change made?

Andrew has indicated that collection is not required.

## Was the documentation (README.md, openapi.yml) updated?

yes

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
