### PR TITLE
Remove external identifier as file attribute in openapi.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -298,8 +298,6 @@ components:
           type: string
         filename:
           type: string
-        externalIdentifier:
-          type: string
         hasMimeType:
           type: string
         use:
@@ -319,7 +317,6 @@ components:
       required:
         - label
         - filename
-        - externalIdentifier
         - administrative
         - access
     BackgroundJobResultResponse:


### PR DESCRIPTION
## Why was this change made?
External identifier is an attribute of a File not a Request File.

See https://github.com/sul-dlss/cocina-models/blob/master/lib/cocina/models/file.rb#L45


## Was the documentation (README.md, openapi.yml) updated?
Yes.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.