### PR TITLE
Add a proxy request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,8 @@ class ApplicationController < ActionController::API
   include RequestAuthorization
   include ActionPolicy::Controller
   authorize :user, through: :current_user
+
+  rescue_from(ActionPolicy::Unauthorized) do |_exp|
+    render json: { error: 'Not Authorized' }, status: :unauthorized
+  end
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -7,11 +7,29 @@ class AuthenticationController < ApplicationController
   def login
     @user = User.find_by_email(params[:email])
     if @user&.authenticate(params[:password])
-      exp = Time.now + 24.hours.to_i
-      token = JsonWebToken.encode({ user_id: @user.id }, exp)
-      render json: { token: token, exp: exp.strftime('%m-%d-%Y %H:%M') }, status: :ok
+      render json: make_token_response(@user), status: :ok
     else
       render json: { error: 'unauthorized' }, status: :unauthorized
     end
+  end
+
+  # POST /auth/proxy
+  # This allows argo to retrieve the token for other users.
+  # We are trusting that argo is verifying the users identity (via Shibboleth)
+  # Then it can give the user their token so they can make an API call without
+  # having a password in sdr-api.
+  def proxy
+    authorize! :account
+    user = User.create_with(password: SecureRandom.urlsafe_base64)
+               .find_or_create_by(email: params[:to])
+    render json: make_token_response(user), status: :ok
+  end
+
+  private
+
+  def make_token_response(user)
+    exp = Time.now + 24.hours.to_i
+    token = JsonWebToken.encode({ user_id: user.id }, exp)
+    { token: token, exp: exp.strftime('%m-%d-%Y %H:%M') }
   end
 end

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# A policy to govern access to other accounts
+class AccountPolicy < ApplicationPolicy
+  # Only argo should be allowed to proxy to other users
+  def proxy?
+    user.email == Settings.argo_user
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ require 'sidekiq/web'
 
 Rails.application.routes.draw do
   scope 'v1' do
-    # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
     post '/auth/login', to: 'authentication#login'
+    post '/auth/proxy', to: 'authentication#proxy'
 
     resources :resources, only: [:create]
     resources :background_job_results, only: [:show], defaults: { format: :json }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,3 +11,8 @@ workflow:
   url: 'http://localhost:3001'
 
 staging_location: '/dor/workspace'
+
+
+# This user is allowed to proxy other users, we expect that it'll be argo and it
+# will be responible for only proxying users which it has verififed with Shibboleth.
+argo_user: argo@dlss.sul.stanford.edu

--- a/openapi.yml
+++ b/openapi.yml
@@ -155,6 +155,35 @@ paths:
                   description: password of the user
                   type: string
                   example: sekr3t!
+  /v1/auth/proxy:
+    post:
+      tags:
+        - authentication
+      summary: Retrieve a JSON web token for a different user
+      operationId: 'authentication#proxy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    description: The access token
+                    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+                  exp:
+                    type: string
+                    description: When the token will expire
+                    format: date-time
+      parameters:
+        - in: query
+          name: to
+          description: The email of the user to proxy to
+          required: true
+          schema:
+            type: string
 components:
   schemas:
     Druid:

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :user
+  sequence :email do |n|
+    "person#{n}@example.com"
+  end
+
+  factory :user do
+    email { generate(:email) }
+    password { 'password' }
+  end
 end

--- a/spec/policies/account_policy_spec.rb
+++ b/spec/policies/account_policy_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountPolicy, type: :policy do
+  # See https://actionpolicy.evilmartians.io/#/testing?id=rspec-dsl
+  let(:user) { build_stubbed :user }
+  let(:context) { { user: user } }
+
+  describe_rule :proxy? do
+    succeed 'when the user is argo' do
+      before { user.email = Settings.argo_user }
+    end
+
+    failed 'when user is not argo'
+  end
+end

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Authorization' do
       User.create!(email: 'jcoyne85@stanford.edu', password: 'sekr3t!')
     end
 
-    it 'Logs tokens to honeybadger' do
+    it 'returns a token' do
       post '/v1/auth/login',
            params: { email: 'jcoyne85@stanford.edu', password: 'sekr3t!' }.to_json,
            headers: { 'Content-Type' => 'application/json' }

--- a/spec/requests/proxy_authorization_spec.rb
+++ b/spec/requests/proxy_authorization_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Proxy Authorization' do
+  let(:to) do
+    create(:user, email: 'jcoyne85@stanford.edu')
+  end
+
+  before do
+    post "/v1/auth/proxy?to=#{to.email}",
+         headers: { 'Authorization' => "Bearer #{jwt(as)}" }
+  end
+
+  context 'when the requestor is authorized' do
+    let(:as) do
+      create(:user, email: 'argo@dlss.sul.stanford.edu')
+    end
+
+    it 'grants a token for the proxied user' do
+      expect(JSON.parse(response.body)['token']).to be_present
+      expect(response).to be_ok
+    end
+  end
+
+  context 'when the requestor is not authorized' do
+    let(:as) do
+      create(:user, email: 'joe@dlss.sul.stanford.edu')
+    end
+
+    it 'returns unauthorized' do
+      expect(response).to be_unauthorized
+    end
+  end
+end

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
 module AuthHelper
-  def jwt
-    JsonWebToken.encode(payload)
+  def jwt(user = create(:user))
+    JsonWebToken.encode(create_payload(user))
   end
 
   private
 
-  def payload
-    user = User.create!(email: 'jcoyne85@stanford.edu', password: 'sekr3t!')
-
+  def create_payload(user)
     { user_id: user.id }
   end
 end


### PR DESCRIPTION

## Why was this change made?

So that argo can get the credenials to give back to the user.  This will allow them to make a sdr-api deposit.
This change will support integration tests of sdr-api

This is a new take on #158 where I screwed up the rebase/push.

## Was the documentation (README.md, openapi.yml) updated?

n/a

## Does this change affect how this application integrates with other services?

no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
