### PR TITLE
Deletes active storage files after ingest.

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -17,6 +17,7 @@ class IngestJob < ApplicationJob
     # Setting lane_id to low for all, which is appropriate for all current use cases. In the future, may want to make
     # this an API parameter.
     workflow_client.create_workflow_by_name(druid, 'accessionWF', version: 1, lane_id: 'low')
+    delete_from_active_storage(file_nodes)
   ensure
     background_job_result.complete!
   end
@@ -47,5 +48,10 @@ class IngestJob < ApplicationJob
 
     # This can raise ActiveRecord::RecordNotFound if one or more of the files don't exist
     ActiveStorage::Blob.find(file_ids)
+  end
+
+  def delete_from_active_storage(file_nodes)
+    # This is a purge_later so not worried about delete errors.
+    files(file_nodes).each(&:purge_later)
   end
 end

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -54,12 +54,14 @@ RSpec.describe IngestJob, type: :job do
       f.write 'HELLO'
     end
     allow(Dor::Workflow::Client).to receive(:new).and_return(client)
+    allow(ActiveStorage::PurgeJob).to receive(:perform_later)
   end
 
-  it 'creates a workflow' do
+  it 'ingests an object' do
     run
     expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
     expect(client).to have_received(:create_workflow_by_name).with(druid, 'accessionWF', version: 1, lane_id: 'low')
     expect(result).to be_complete
+    expect(ActiveStorage::PurgeJob).to have_received(:perform_later).with(blob)
   end
 end


### PR DESCRIPTION
closes #174

## Why was this change made?
So that we use less scratch space.


## Was the documentation (README.md, openapi.yml) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.