### PR TITLE
Pin dlss-capistrano to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,5 +58,5 @@ group :deployment do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
   gem 'capistrano-sidekiq', require: false
-  gem 'dlss-capistrano', require: false
+  gem 'dlss-capistrano', '~> 3.5', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,7 @@ DEPENDENCIES
   cocina-models (~> 0.31.0)
   committee
   config (~> 2.0)
-  dlss-capistrano
+  dlss-capistrano (~> 3.5)
   dor-services-client (~> 5.1)
   dor-workflow-client
   druid-tools


### PR DESCRIPTION
Do this because when dlss-capistrano 4.0 comes out, codebases that use both dlss-capistrano and capistrano-sidekiq without pinning the former will find it clobbering the sidekiq tasks from the latter, and that will cause confusion and woe.
