### PR TITLE
Add a way to do registration without kicking off accessioning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,8 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/NestedGroups:
+  Max: 4
 
 Style/HashEachMethods:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -10,11 +10,16 @@ An HTTP API for the SDR.
 
 There is a [OAS 3.0 spec](http://spec.openapis.org/oas/v3.0.2) that documents the API in [openapi.yml].  If you clone this repo, you can view this by opening [docs/index.html].
 
-## Deposit
+## Functionality
+### Deposit
 This accepts a series of uploaded files and metadata (Cocina model) and begins the accessioning workflow.
 
-TODO:
-  - Create derivative images for access
+### Register
+Same as deposit, but doesn't begin the accessioning workflow
+
+## Future enhancements
+- Update an existing object. This depends on us having a complete mapping between Cocina descriptive metadata and MODS.
+- Create derivative images for access
 
 ## Local Development / Usage
 

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -28,10 +28,10 @@ class ResourcesController < ApplicationController
     end
 
     result = BackgroundJobResult.create
-
     IngestJob.perform_later(druid: response_cocina_obj.externalIdentifier,
                             filesets: params[:structural].to_unsafe_h.fetch(:contains, []),
-                            background_job_result: result)
+                            background_job_result: result,
+                            start_workflow: params[:accession])
 
     render json: { druid: response_cocina_obj.externalIdentifier },
            location: result,
@@ -43,7 +43,7 @@ class ResourcesController < ApplicationController
   private
 
   def cocina_model
-    model_params = params.except(:action, :controller, :resource).to_unsafe_h
+    model_params = params.except(:action, :controller, :resource, :accession).to_unsafe_h
     model_params[:label] = ':auto' if model_params[:label].nil?
     model_params[:version] = 1 if model_params[:version].nil?
     file_sets(model_params[:structural].fetch(:contains, []))

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -7,7 +7,7 @@ class IngestJob < ApplicationJob
   # @param [String] druid
   # @param [Array<Hash>] filesets the data for creating the structure
   # @param [BackgroundJobResult] background_job_result
-  def perform(druid:, filesets:, background_job_result:)
+  def perform(druid:, filesets:, background_job_result:, start_workflow: true)
     background_job_result.processing!
 
     dir = StagingDirectory.new(druid: druid, staging_location: Settings.staging_location)
@@ -16,7 +16,7 @@ class IngestJob < ApplicationJob
 
     # Setting lane_id to low for all, which is appropriate for all current use cases. In the future, may want to make
     # this an API parameter.
-    workflow_client.create_workflow_by_name(druid, 'accessionWF', version: 1, lane_id: 'low')
+    workflow_client.create_workflow_by_name(druid, 'accessionWF', version: 1, lane_id: 'low') if start_workflow
     delete_from_active_storage(file_nodes)
   ensure
     background_job_result.complete!

--- a/openapi.yml
+++ b/openapi.yml
@@ -108,6 +108,11 @@ paths:
           description: Bad gateway for DOR or workflow services
         '504':
           description: Gateway timeout
+      parameters:
+        - in: query
+          name: accession
+          schema:
+            type: boolean
       requestBody:
         description: The metadata for the object
         required: true


### PR DESCRIPTION
## Why was this change made?

So that we have a way to register without accessioning.

## Was the documentation (README.md, openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
