### PR TITLE
Upgrade to dlss-capistrano 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,8 @@ jobs:
       - run:
           name: Build against master branch
           command: |
+            git config --global user.name "sul-devops-team"
+            git config --global user.email "sul-devops-team@lists.stanford.edu"
             git config --global url."https://github.com/".insteadOf git@github.com:
             git fetch origin && git merge --no-edit origin/master
             if [[ $? -ne 0 ]]; then

--- a/Capfile
+++ b/Capfile
@@ -36,7 +36,6 @@ require 'capistrano/passenger'
 require 'capistrano/honeybadger'
 # require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
-require 'capistrano/sidekiq'
 require 'dlss/capistrano'
 require 'whenever/capistrano'
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,5 @@ end
 group :deployment do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
-  gem 'capistrano-sidekiq', require: false
-  gem 'dlss-capistrano', '~> 3.5', require: false
+  gem 'dlss-capistrano', '~> 3.6', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundle_audit (0.2.2)
+    capistrano-bundle_audit (0.3.0)
       bundler-audit (~> 0.5)
       capistrano (~> 3.0)
       capistrano-bundler (~> 1.4)
@@ -96,9 +96,6 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    capistrano-sidekiq (1.0.3)
-      capistrano (>= 3.9.0)
-      sidekiq (>= 3.4, < 6.0)
     chronic (0.10.2)
     cocina-models (0.31.1)
       activesupport
@@ -126,9 +123,9 @@ GEM
     deprecation (1.0.0)
       activesupport
     diff-lcs (1.3)
-    dlss-capistrano (3.5.0)
+    dlss-capistrano (3.6.0)
       capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.1.0)
+      capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.2)
@@ -244,9 +241,9 @@ GEM
       nokogiri-happymapper
     msgpack (1.3.3)
     multipart-post (2.1.1)
-    net-scp (2.0.0)
-      net-ssh (>= 2.6.5, < 6.0.0)
-    net-ssh (5.2.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (6.0.0)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -390,11 +387,10 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  capistrano-sidekiq
   cocina-models (~> 0.31.0)
   committee
   config (~> 2.0)
-  dlss-capistrano (~> 3.5)
+  dlss-capistrano (~> 3.6)
   dor-services-client (~> 5.1)
   dor-workflow-client
   druid-tools

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,11 +25,6 @@ append :linked_files, 'config/database.yml', 'config/honeybadger.yml', 'config/s
 # Default value for linked_dirs is []
 append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'config/settings', 'vendor/bundle', 'storage'
 
-# Sidekiq configuration (run three processes)
-# see sidekiq.yml for concurrency and queue settings
-set :sidekiq_processes, 3
-set :sidekiq_env, 'production'
-
 # Default value for default_env is {}
 # set :default_env, { path: '/opt/ruby/bin:$PATH' }
 
@@ -44,6 +39,15 @@ set :sidekiq_env, 'production'
 
 # Honeybadger will otherwise default to `Rails.env`
 set :honeybadger_env, fetch(:stage)
+
+# Set Rails env to production in all Cap environments
+set :rails_env, 'production'
+
+# Allow dlss-capistrano to manage sidekiq via systemd
+set :sidekiq_systemd_use_hooks, true
+
+# Use bundler2-style configuration (from dlss-capistrano)
+set :bundler2_config_use_hook, true
 
 # Update shared_configs as part of deployment process
 before 'deploy:restart', 'shared_configs:update'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -3,5 +3,3 @@
 server 'sdr-api-prod.stanford.edu', user: 'sdr', roles: %w[app db web]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, 'production'
-set :bundle_without, %w[deployment test development].join(' ')

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -3,5 +3,3 @@
 server 'sdr-api-qa.stanford.edu', user: 'sdr', roles: %w[app db web]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, 'production'
-set :bundle_without, %w[deployment test development].join(' ')

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -3,5 +3,3 @@
 server 'sdr-api-stage.stanford.edu', user: 'sdr', roles: %w[app db web]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, 'production'
-set :bundle_without, %w[deployment test development].join(' ')


### PR DESCRIPTION
Blocked by https://github.com/sul-dlss/puppet/pull/5289

## Why was this change made?

Consistency w/ other projects, keeping pace with sidekiq.

As part of this:
* Allow dlss-capistrano to manage sidekiq
* Opt-in to dlss-capistrano bundler 2-style configuration

Also:
* Move rails_env setting to deploy.rb since this does not vary per-env


## Was the documentation (README.md, openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?

No.