### PR TITLE
Fixes merging of BackgroundJobResult output for IngestJob.

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -51,7 +51,8 @@ class IngestJob < ApplicationJob
     end
 
     # Otherwise return an error on background_job_result but exit cleanly.
-    background_job_result.output.merge!({ errors: [title: 'All retries failed', message: e.message] })
+    background_job_result.output = background_job_result.output.merge({ errors: [title: 'All retries failed',
+                                                                                 message: e.message] })
     background_job_result.complete!
   end
   # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
## Why was this change made?
The use of `merge!` was not updating output. This was causing Google Books to fail because it was expecting certain values in output.


## How was this change tested?
Unit tests. To be tested in stage.


## Which documentation and/or configurations were updated?
No.


