### PR TITLE
Ignore symphony

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Honeybadger.configure do |config|
+  config.before_notify do |notice|
+    # Symphony is unavailable
+    notice.halt! if notice.error_message =~ /unableToAcquireSession/
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 sdr_api:
   days_after_which_to_remove_uploads: 7
   blob_batch_size: 20
-  ingest_retries: 5
+  ingest_retries: 8 # ~1.5 hours. See https://github.com/mperham/sidekiq/wiki/Error-Handling
 
 dor_services:
   url: 'http://localhost:3003'

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe IngestJob, type: :job do
     end
 
     context 'without retries' do
-      let(:try_count) { 5 }
+      let(:try_count) { 8 }
 
       it 'quits' do
         described_class.perform_now(model_params: model, background_job_result: result, signed_ids: signed_ids)


### PR DESCRIPTION
## Why was this change made?
To account for nightly Symphony outages by:
* Not HB alerting.
* Retry enough to get pass outages.

## How was this change tested?
To be tested on stage.


## Which documentation and/or configurations were updated?
Yes.


