### PR TITLE
Remove sidekiq retry config.

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -5,7 +5,8 @@
 # Above that, it will exit and provide the error message in the background_job_result.
 class IngestJob < ApplicationJob
   queue_as :default
-  sidekiq_options retry: Settings.sdr_api.ingest_retries
+  # Note that deciding when to stop retrying is handled below. Hence, not providing additional retry configuration
+  # for Sidekiq.
 
   # @param [Hash] model_params
   # @param [Array<String>] signed_ids for the blobs


### PR DESCRIPTION
## Why was this change made?
The sidekiq config was causing jobs to be moved to dead, rather than use custom retry logic.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
None


