### PR TITLE
Tighten up druid matching from error message.

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -30,7 +30,7 @@ class IngestJob < ApplicationJob
         return
       end
       # Get the druid from the error message
-      druid = /\((druid:.+)\)/.match(e.message)[1]
+      druid = /\((druid:.{11})\)/.match(e.message)[1]
     end
     background_job_result.output = { druid: druid }
 


### PR DESCRIPTION
## Why was this change made?
Capturing more than hoped: `\"druid:hp141bb0993) with the source ID 'googlebooks:stanford_36105050072466' has already been registered.`.


## How was this change tested?
Unit.


## Which documentation and/or configurations were updated?
No


