### PR TITLE
Rollback accepting an integer value in the description

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -528,7 +528,10 @@ components:
               description: String or integer value of the descriptive element.
               oneOf:
                 - type: string
-                - type: integer
+              # Title note (nonsorting character count) was supposed to be able to accept an integer value,
+              # but this triggered a bug in committee:
+              # https://github.com/interagent/committee/issues/286
+              # - type: integer
             type:
               description: Type of value provided by the descriptive element.
               type: string


### PR DESCRIPTION

## Why was this change made?
Committee can't decide which type this is.
See interagent/committee#286
Fixes sul-dlss/happy-heron#194
Ref sul-dlss/cocina-models#144
Ref sul-dlss/dor-services-app#1073



## How was this change tested?



## Which documentation and/or configurations were updated?



