### PR TITLE
Set RequestDRO additionalProperties to true.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1216,7 +1216,8 @@ components:
     RequestDRO:
       description: A request to create a DRO.  This has the same general structure as a DRO but doesn't have externalIdentifier and doesn't require the access subschema. If no access subschema is provided, these values will be inherited from the AdminPolicy.
       type: object
-      additionalProperties: false
+      # Committee requires this to be true in order to allow an endpoint using the schema to have query params.
+      additionalProperties: true
       properties:
         type:
           type: string


### PR DESCRIPTION
## Why was this change made?
In order for committee to allow the `accession` query param, `additionalProperties` has to be set to true.


## How was this change tested?
Integration


## Which documentation and/or configurations were updated?
openapi


