### PR TITLE
Change the response code for update from created

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -47,7 +47,7 @@ class ResourcesController < ApplicationController
 
     render json: { jobId: result.id },
            location: result,
-           status: :created
+           status: :accepted
   end
 
   private

--- a/spec/requests/update_resource_spec.rb
+++ b/spec/requests/update_resource_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'Update a resource' do
         params: request,
         headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
 
-    expect(response).to be_created
+    expect(response).to be_accepted
     expect(response.location).to be_present
     expect(JSON.parse(response.body)['jobId']).to be_present
     expect(UpdateJob).to have_received(:perform_later).with(model_params: expected_model_params,


### PR DESCRIPTION
To the more appropriate "accepted" (202).

## Why was this change made?

201 is not an appropriate code for updating a resource.

## How was this change tested?



## Which documentation and/or configurations were updated?



