### PR TITLE
Make the error message match the openapi spec

### DIFF
--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -25,7 +25,9 @@ class UpdateJob < ApplicationJob
     if existing.version >= model.version
       background_job_result.output = {
         errors: [
-          version: "The repository already has '#{existing.version}', and you provided '#{model.version}'"
+          title: 'Version conflict',
+          detail: "The repository already has a version '#{existing.version}' for " \
+                  "#{existing.externalIdentifier}, and you provided '#{model.version}'"
         ]
       }
       background_job_result.complete!

--- a/spec/jobs/update_job_spec.rb
+++ b/spec/jobs/update_job_spec.rb
@@ -183,7 +183,10 @@ RSpec.describe UpdateJob, type: :job do
       described_class.perform_now(model_params: model, background_job_result: result, signed_ids: signed_ids)
       expect(actual_result).to be_complete
       expect(actual_result.output[:errors]).to eq [
-        { 'version' => "The repository already has '2', and you provided '2'" }
+        {
+          'title' => 'Version conflict',
+          'detail' => "The repository already has a version '2' for druid:bc123dg5678, and you provided '2'"
+        }
       ]
     end
   end


### PR DESCRIPTION
## Why was this change made?
The errors were in the wrong format for the client.


## How was this change tested?



## Which documentation and/or configurations were updated?



