### PR TITLE
openapi.yml: updated with digitalLocation for access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,10 +20,10 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'action_policy'
 gem 'assembly-objectfile', '~> 1.9'
-gem 'cocina-models', '~> 0.43.0'
+gem 'cocina-models', '~> 0.44.0'
 gem 'committee'
 gem 'config', '~> 2.0'
-gem 'dor-services-client', '~> 6.15'
+gem 'dor-services-client', '~> 6.16'
 gem 'dor-workflow-client'
 gem 'druid-tools'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.43.0)
+    cocina-models (0.44.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -130,9 +130,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.2)
-    dor-services-client (6.15.0)
+    dor-services-client (6.16.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.43.0)
+      cocina-models (~> 0.44.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -391,11 +391,11 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.43.0)
+  cocina-models (~> 0.44.0)
   committee
   config (~> 2.0)
   dlss-capistrano (~> 3.6)
-  dor-services-client (~> 6.15)
+  dor-services-client (~> 6.16)
   dor-workflow-client
   druid-tools
   equivalent-xml

--- a/openapi.yml
+++ b/openapi.yml
@@ -498,6 +498,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
+        digitalLocation:
+          description: Location of a digital version of the resource, such as a file path for a born digital resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
         accessContact:
           description: The library, organization, or person responsible for access to the resource.
           type: array


### PR DESCRIPTION
## Why was this change made?

openapi.yml needs to be kept in sync with cocina-models, and the gems need to be kept in sync.

For mapping ticket sul-dlss/dor-services-app#1499, we need cocina-models DescriptiveAccessMetadata to have digitalLocation; this tiny additive change to openapi.yml was merged into cocina-models. I've just generated the new cocina-models gem release, 0.44.0 and dor-services-client 6.16.0 to reflect this change.

## How was this change tested?



## Which documentation and/or configurations were updated?



