### PR TITLE
Add an endpoint to expose the metadata

### DIFF
--- a/app/policies/resource_policy.rb
+++ b/app/policies/resource_policy.rb
@@ -4,8 +4,16 @@
 class ResourcePolicy < ApplicationPolicy
   # See https://actionpolicy.evilmartians.io/#/writing_policies
 
-  # Any use with an account can create or update resources
+  # Any user with an account can create or update resources
   def create?
+    true
+  end
+
+  # Any user with an account can read the resources
+  # TODO: We should add restrictions like Argo does:
+  #   A user in the admin group or workgroup:sdr:viewer-role
+  #   or the APO for this item has one of the users groups set for the dor-apo-manager role
+  def show?
     true
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     post '/auth/login', to: 'authentication#login'
     post '/auth/proxy', to: 'authentication#proxy'
 
-    resources :resources, only: %i[create update]
+    resources :resources, only: %i[create update show]
     resources :background_job_results, only: [:show], defaults: { format: :json }
 
     # We don't need all of the activestorage routes, just these few:

--- a/openapi.yml
+++ b/openapi.yml
@@ -120,6 +120,41 @@ paths:
                 - $ref: '#/components/schemas/RequestDRO'
                 - $ref: '#/components/schemas/RequestCollection'
   /v1/resources/{id}:
+    get:
+      tags:
+        - objects
+      summary: Retrieve the object metadata
+      description: 'Returns a JSON representation of an object, collection or admin policy.'
+      operationId: 'resources#show'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/DRO'
+                  - $ref: '#/components/schemas/Collection'
+                  - $ref: '#/components/schemas/AdminPolicy'
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      parameters:
+        - name: id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
     put:
       tags:
         - objects

--- a/spec/requests/retrieve_resource_spec.rb
+++ b/spec/requests/retrieve_resource_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Retrieve a resource' do
+  let(:request) do
+    <<~JSON
+      {
+        "label":"hello",
+        "externalIdentifier":"druid:bc999dg9999",
+        "version":2,
+        "type":"#{Cocina::Models::Vocab.book}",
+        "access": {
+          "access":"world",
+          "copyright":"All rights reserved unless otherwise indicated.",
+          "download":"none",
+          "useAndReproductionStatement":"Property rights reside with the repository...",
+          "embargo": {
+            "releaseDate": "2029-06-22T07:00:00.000+00:00",
+            "access": "world",
+            "useAndReproductionStatement": "Whatever you want"
+          }
+        },
+        "administrative": {
+          "hasAdminPolicy":"druid:bc123df4567",
+          "partOfProject":"Google Books",
+          "releaseTags":[]
+        },
+        "identification": {
+          "catalogLinks": [
+              {
+                "catalog":"symphony",
+                "catalogRecordId":"123456"
+              }
+          ],
+          "sourceId":"googlebooks:stanford_82323429"
+        },
+        #{structural}
+      }
+    JSON
+  end
+
+  let(:structural) do
+    <<~JSON
+      "structural":{
+        "isMemberOf":["druid:fg123hj4567"],
+        "contains":[
+          {
+            "type":"http://cocina.sul.stanford.edu/models/fileset.jsonld",
+            "externalIdentifier":"9999",
+            "label":"Page 1",
+            "structural":{
+              "contains":[]
+            },
+            "version":2
+          }
+        ]
+      }
+    JSON
+  end
+
+  before do
+    stub_request(:get, 'http://localhost:3003/v1/objects/druid:bc999dg9999')
+      .to_return(status: 200, body: request, headers: {})
+  end
+
+  it 'returns the cocina model' do
+    get '/v1/resources/druid:bc999dg9999',
+        headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+    expect(response).to be_successful
+    expect(JSON.parse(response.body)['externalIdentifier']).to eq 'druid:bc999dg9999'
+  end
+end


### PR DESCRIPTION
## Why was this change made?
So that H2 can migrate collections.


## How was this change tested?



## Which documentation and/or configurations were updated?



