### PR TITLE
Updates cocina model to 0.49.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,10 +20,10 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'action_policy'
 gem 'assembly-objectfile', '~> 1.9'
-gem 'cocina-models', '~> 0.48.0'
+gem 'cocina-models', '~> 0.49.0'
 gem 'committee'
 gem 'config', '~> 2.0'
-gem 'dor-services-client', '~> 6.20'
+gem 'dor-services-client', '~> 6.21'
 gem 'dor-workflow-client'
 gem 'druid-tools'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.48.0)
+    cocina-models (0.49.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -135,9 +135,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.5)
-    dor-services-client (6.20.0)
+    dor-services-client (6.21.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.48.0)
+      cocina-models (~> 0.49.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -400,11 +400,11 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.48.0)
+  cocina-models (~> 0.49.0)
   committee
   config (~> 2.0)
   dlss-capistrano (~> 3.6)
-  dor-services-client (~> 6.20)
+  dor-services-client (~> 6.21)
   dor-workflow-client
   druid-tools
   equivalent-xml

--- a/openapi.yml
+++ b/openapi.yml
@@ -911,6 +911,7 @@ components:
       additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
+        - $ref: "#/components/schemas/DescriptiveParallelValue"
         - type: object
           additionalProperties: false
           properties:


### PR DESCRIPTION
## Why was this change made?
Keep cocina models in sync.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
openapi.yml


