### PR TITLE
tests for passing accession flag to /resource, rubocop touchups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,12 +35,6 @@ RSpec/NestedGroups:
 
 Gemspec/DateAssignment: # (new in 1.10)
   Enabled: true
-Style/HashEachMethods:
-  Enabled: true
-Style/HashTransformKeys:
-  Enabled: true
-Style/HashTransformValues:
-  Enabled: true
 Layout/SpaceBeforeBrackets: # (new in 1.7)
   Enabled: true
 Lint/AmbiguousAssignment: # (new in 1.7)
@@ -85,7 +79,13 @@ Style/EndlessMethod: # (new in 1.8)
   Enabled: true
 Style/HashConversion: # (new in 1.10)
   Enabled: true
+Style/HashEachMethods:
+  Enabled: true
 Style/HashExcept: # (new in 1.7)
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
   Enabled: true
 Style/IfWithBooleanLiteralBranches: # (new in 1.9)
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,11 +33,19 @@ RSpec/MultipleExpectations:
 RSpec/NestedGroups:
   Max: 4
 
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
 Style/HashEachMethods:
   Enabled: true
 Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
+  Enabled: true
+Layout/SpaceBeforeBrackets: # (new in 1.7)
+  Enabled: true
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+Lint/DeprecatedConstants: # (new in 1.8)
   Enabled: true
 Lint/DuplicateBranch: # (new in 1.3)
   Enabled: true
@@ -47,9 +55,21 @@ Lint/EmptyBlock: # (new in 1.1)
   Enabled: true
 Lint/EmptyClass: # (new in 1.3)
   Enabled: true
+Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: true
 Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
   Enabled: true
+Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: true
+Lint/OrAssignmentToConstant: # (new in 1.9)
+  Enabled: true
+Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
+Lint/SymbolConversion: # (new in 1.9)
+  Enabled: true
 Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+Lint/TripleQuotes: # (new in 1.9)
   Enabled: true
 Lint/UnexpectedBlockArity: # (new in 1.5)
   Enabled: true
@@ -60,6 +80,14 @@ Style/ArgumentsForwarding: # (new in 1.1)
 Style/CollectionCompact: # (new in 1.2)
   Enabled: true
 Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: true
+Style/EndlessMethod: # (new in 1.8)
+  Enabled: true
+Style/HashConversion: # (new in 1.10)
+  Enabled: true
+Style/HashExcept: # (new in 1.7)
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # (new in 1.9)
   Enabled: true
 Style/NegatedIfElseCondition: # (new in 1.2)
   Enabled: true

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -138,9 +138,9 @@ class ResourcesController < ApplicationController
       json: {
         errors: [
           {
-            "status": error_code,
-            "title": msg,
-            "detail": err.message
+            status: error_code,
+            title: msg,
+            detail: err.message
           }
         ]
       },

--- a/spec/requests/create_resource_spec.rb
+++ b/spec/requests/create_resource_spec.rb
@@ -156,6 +156,30 @@ RSpec.describe 'Create a resource' do
                                                               start_workflow: nil)
     end
 
+    context 'when the accession flag is explcitly set to true' do
+      it 'kicks off accession workflow' do
+        post '/v1/resources?accession=true',
+             params: request,
+             headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+        expect(IngestJob).to have_received(:perform_later).with(model_params: expected_model_params,
+                                                                background_job_result: instance_of(BackgroundJobResult),
+                                                                signed_ids: [signed_id],
+                                                                start_workflow: true)
+      end
+    end
+
+    context 'when the accession flag is explcitly set to false' do
+      it 'does not kick off accession workflow' do
+        post '/v1/resources?accession=false',
+             params: request,
+             headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+        expect(IngestJob).to have_received(:perform_later).with(model_params: expected_model_params,
+                                                                background_job_result: instance_of(BackgroundJobResult),
+                                                                signed_ids: [signed_id],
+                                                                start_workflow: false)
+      end
+    end
+
     context 'when blob not found for file' do
       let(:signed_id) { 'abc123' }
 


### PR DESCRIPTION
pass as URL param, as sdr-client does.

## Why was this change made?

show that the `accession` parameter is passed along correctly to `IngestJob` by the `/resources` route.

see also https://github.com/sul-dlss/sdr-client/pull/148

## How was this change tested?

tests only

## Which documentation and/or configurations were updated?

n/a

