### PR TITLE
modify UpdateJob so it accessions by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 4
 

--- a/spec/jobs/update_job_spec.rb
+++ b/spec/jobs/update_job_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe UpdateJob, type: :job do
     {
       type: Cocina::Models::Vocab.book,
       label: 'hello',
-      externalIdentifier: 'druid:bc123dg5678',
+      externalIdentifier: druid,
       version: 2,
       access: {
         copyright: 'All rights reserved unless otherwise indicated.',
@@ -59,7 +59,7 @@ RSpec.describe UpdateJob, type: :job do
     {
       type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
       filename: 'file2.txt',
-      externalIdentifier: 'druid:bc123dg5678/file2.txt',
+      externalIdentifier: "#{druid}/file2.txt",
       label: 'file2.txt',
       hasMimeType: 'text/plain',
       administrative: {
@@ -104,7 +104,7 @@ RSpec.describe UpdateJob, type: :job do
       f.write 'HELLO'
     end
     allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
-    allow(Dor::Services::Client).to receive(:object).with('druid:bc123dg5678').and_return(object_client)
+    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
     allow(ActiveStorage::PurgeJob).to receive(:perform_later)
   end
 


### PR DESCRIPTION
## Why was this change made?

also, add slightly stricter version checking, and alert when there are versioning problems

connects to https://github.com/sul-dlss/happy-heron/issues/1248

## How was this change tested?

- [x] unit tests
  - [x] add a test for versions match but object is open
  - [x] test for HB notifications
- [x] deploy to QA
  - [x] initial PURL res descriptive metadata now fails roundtrip validation when registering the SDR object, so testing of this change (which modifies the update call made after the purl is successfully reserved) is temporarily blocked.  see https://app.honeybadger.io/projects/50568/faults/78470985
    - `Cocina::RoundtripValidationError: Roundtripping of descriptive metadata unsuccessful. Expected {:title=>[{:value=>"purl res, sdr-api commit 3b8a1d6b"}], :contributor=>[], :event=>[], :form=>[{:structuredValue=>[{:value=>"PURL reservation", :type=>"type"}], :type=>"resource type", :source=>{:value=>"Stanford self-deposit resource types"}}], :note=>[{:value=>"", :type=>"summary"}, {}], :subject=>[], :relatedResource=>[]} but received {:title=>[{:value=>"purl res, sdr-api commit 3b8a1d6b"}], :form=>[{:type=>"resource type", :source=>{:value=>"Stanford self-deposit resource types"}, :structuredValue=>[{:value=>"PURL reservation", :type=>"type"}]}]}.`
    - sounds like this is actually a more general H2 mapping problem, see https://github.com/sul-dlss/dor-services-app/issues/2557
  - [x] test on QA

ticketed an integration test:  https://github.com/sul-dlss/infrastructure-integration-test/issues/211

## Which documentation and/or configurations were updated?



