### PR TITLE
Check that the client is compatible before trying to process the request

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -7,6 +7,7 @@ class ResourcesController < ApplicationController
   class BlobError < StandardError; end
 
   before_action :authorize_request
+  before_action :validate_version
 
   # POST /resource
   def create
@@ -58,6 +59,15 @@ class ResourcesController < ApplicationController
   end
 
   private
+
+  def validate_version
+    request_version = request.headers['X-Cocina-Models-Version']
+    return if !request_version || request_version == Cocina::Models::VERSION
+
+    error = StandardError.new("The API accepts cocina-models version #{Cocina::Models::VERSION} " \
+      "but you provided #{request_version}.  Run \"bundle update\" and then retry your request.")
+    render build_error('400', error, 'Cocina-models version mismatch')
+  end
 
   def cocina_model(model_params)
     new_model_params = model_params.deep_dup

--- a/spec/requests/create_resource_spec.rb
+++ b/spec/requests/create_resource_spec.rb
@@ -157,6 +157,21 @@ RSpec.describe 'Create a resource' do
                                                               start_workflow: nil)
     end
 
+    context 'when wrong version of cocina models is supplied' do
+      it 'returns 400' do
+        post '/v1/resources?accession=true',
+             params: request,
+             headers: {
+               'Content-Type' => 'application/json',
+               'Authorization' => "Bearer #{jwt}",
+               'X-Cocina-Models-Version' => '0.33.1'
+             }
+        expect(response).to have_http_status(:bad_request)
+        body = JSON.parse(response.body)
+        expect(body['errors'][0]['title']).to eq 'Cocina-models version mismatch'
+      end
+    end
+
     context 'when the accession flag is explcitly set to true' do
       it 'kicks off accession workflow' do
         post '/v1/resources?accession=true',

--- a/spec/requests/update_resource_spec.rb
+++ b/spec/requests/update_resource_spec.rb
@@ -117,6 +117,21 @@ RSpec.describe 'Update a resource' do
                                                             signed_ids: [signed_id])
   end
 
+  context 'when wrong version of cocina models is supplied' do
+    it 'returns 400' do
+      put '/v1/resources/druid:bc123df4567',
+          params: request,
+          headers: {
+            'Content-Type' => 'application/json',
+            'Authorization' => "Bearer #{jwt}",
+            'X-Cocina-Models-Version' => '0.33.1'
+          }
+      expect(response).to have_http_status(:bad_request)
+      body = JSON.parse(response.body)
+      expect(body['errors'][0]['title']).to eq 'Cocina-models version mismatch'
+    end
+  end
+
   context 'when blob not found for file' do
     let(:signed_id) { 'abc123' }
 


### PR DESCRIPTION
## Why was this change made?

So that people can know when they are trying to use an out of date client.

## How was this change tested?



## Which documentation and/or configurations were updated?



