### PR TITLE
Allow the redis url to be configured

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: Settings.redis_url }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: Settings.redis_url }
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,3 +17,5 @@ staging_location: '/dor/workspace'
 # This user is allowed to proxy other users, we expect that it'll be argo and it
 # will be responible for only proxying users which it has verififed with Shibboleth.
 argo_user: argo@dlss.sul.stanford.edu
+
+redis_url: 'redis://localhost:6379/'


### PR DESCRIPTION


## Why was this change made?

So we can use the docker container for testing

## How was this change tested?



## Which documentation and/or configurations were updated?



