### PR TITLE
Run workers asynchronously in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,10 @@ Rails.application.configure do
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  config.active_job.queue_adapter = :sidekiq
+  # Use the async adapter in development mode, so we can use one container
+  # (rather than two containers) for sdr-api in the Argo test suite.
+  config.active_job.queue_adapter = :async
+
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 end


### PR DESCRIPTION


## Why was this change made?
This allows us to test in argo without having to spin up a container just for the workers


## How was this change tested?



## Which documentation and/or configurations were updated?



