### PR TITLE
Configure Host Authorization for argo testing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ Layout/LineLength:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb
+    - config/environments/*.rb
 
 RSpec/DescribeClass:
   Exclude:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,4 +69,9 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # configure Host Authorization middleware.
+  # Allow the application to be named 'sdr-api' so that this container can be run
+  # by argo in circle-ci
+  config.hosts << 'sdr-api'
 end


### PR DESCRIPTION
## Why was this change made?
Rails has a middleware that prevents DNS rebinding.  So when we run this container in CircleCI it needs to allow binding to its name.


## How was this change tested?



## Which documentation and/or configurations were updated?



