### PR TITLE
add lane medical library barcode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.59.0)
+    cocina-models (0.59.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)

--- a/openapi.yml
+++ b/openapi.yml
@@ -462,6 +462,7 @@ components:
       description: 'A barcode'
       oneOf:
         - $ref: '#/components/schemas/BusinessBarcode'
+        - $ref: '#/components/schemas/LaneMedicalBarcode'
         - $ref: '#/components/schemas/CatkeyBarcode'
         - $ref: '#/components/schemas/StandardBarcode'
     BusinessBarcode:
@@ -469,6 +470,11 @@ components:
       type: string
       pattern: '^2050[0-9]{7}$'
       example: 20503740296
+    LaneMedicalBarcode:
+      description: The barcode associated with a Lane Medical Library DRO object, prefixed with 245
+      type: string
+      pattern: '^245[0-9]{8}$'
+      example: 24503259768
     CatalogLink:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## Why was this change made?

Part of sul-dlss/dor-services-app#2851 - validate lane medical barcodes

~~[HOLD] for sul-dlss/cocina-models#262 and updated version of the gem~~

## How was this change tested?



## Which documentation and/or configurations were updated?



