### PR TITLE
Revert "Bump cocina-models to 0.60.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'action_policy'
 gem 'assembly-objectfile', '~> 1.9'
-gem 'cocina-models', '~> 0.60.0'
+gem 'cocina-models', '~> 0.59.0'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 6.33'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.60.0)
+    cocina-models (0.59.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -117,7 +117,7 @@ GEM
       rack (>= 1.5)
     commonmarker (0.21.2)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.8)
     config (2.2.3)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
@@ -135,9 +135,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (6.35.0)
+    dor-services-client (6.34.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.60.0)
+      cocina-models (~> 0.59.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -154,10 +154,10 @@ GEM
     dry-configurable (0.12.1)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5.0)
-    dry-container (0.8.0)
+    dry-container (0.7.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.6.0)
+    dry-core (0.5.0)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.3.0)
     dry-inflector (0.2.0)
@@ -220,6 +220,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    io-wait (0.1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     json (2.5.1)
@@ -234,7 +235,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.10.0)
+    loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -246,25 +247,32 @@ GEM
     mime-types-data (3.2021.0225)
     mini_exiftool (2.10.1)
     mini_mime (1.0.3)
-    mini_portile2 (2.5.3)
+    mini_portile2 (2.5.2)
+      net-ftp (~> 0.1)
     minitest (5.14.4)
-    moab-versioning (4.4.2)
+    moab-versioning (4.4.1)
       druid-tools (>= 1.0.0)
       json
       nokogiri
       nokogiri-happymapper
     msgpack (1.4.2)
     multipart-post (2.1.1)
+    net-ftp (0.1.2)
+      net-protocol
+      time
+    net-protocol (0.1.1)
+      io-wait
+      timeout
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
     nio4r (2.5.7)
-    nokogiri (1.11.7)
+    nokogiri (1.11.6)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.7-x86_64-darwin)
+    nokogiri (1.11.6-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.11.7-x86_64-linux)
+    nokogiri (1.11.6-x86_64-linux)
       racc (~> 1.4)
     nokogiri-happymapper (0.8.1)
       nokogiri (~> 1.5)
@@ -338,13 +346,13 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    rubocop (1.16.0)
+    rubocop (1.15.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 1.5.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.7.0)
@@ -386,6 +394,8 @@ GEM
       net-ssh (>= 2.8.0)
     thor (1.1.0)
     tilt (2.0.10)
+    time (0.1.0)
+    timeout (0.1.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
@@ -413,7 +423,7 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.60.0)
+  cocina-models (~> 0.59.0)
   committee
   config (~> 2.0)
   dlss-capistrano (~> 3.6)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1069,37 +1069,6 @@ components:
             license:
               description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
               type: string
-              enum:
-                - https://www.gnu.org/licenses/agpl.txt
-                - https://www.apache.org/licenses/LICENSE-2.0
-                - https://opensource.org/licenses/BSD-2-Clause
-                - https://opensource.org/licenses/BSD-3-Clause
-                - https://creativecommons.org/licenses/by/4.0/legalcode
-                - https://creativecommons.org/licenses/by-nc/4.0/legalcode
-                - https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
-                - https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-                - https://creativecommons.org/licenses/by-nd/4.0/legalcode
-                - https://creativecommons.org/licenses/by-sa/4.0/legalcode
-                - https://creativecommons.org/publicdomain/zero/1.0/legalcode
-                - https://opensource.org/licenses/cddl1
-                - https://www.eclipse.org/legal/epl-2.0
-                - https://www.gnu.org/licenses/gpl-3.0-standalone.html
-                - https://www.isc.org/downloads/software-support-policy/isc-license/
-                - https://www.gnu.org/licenses/lgpl-3.0-standalone.html
-                - https://opensource.org/licenses/MIT
-                - https://www.mozilla.org/MPL/2.0/
-                - https://opendatacommons.org/licenses/by/1-0/
-                - http://opendatacommons.org/licenses/odbl/1.0/ # Non cannonical, but in some of our data
-                - https://opendatacommons.org/licenses/odbl/1-0/
-                - https://creativecommons.org/publicdomain/mark/1.0/
-                - https://opendatacommons.org/licenses/pddl/1-0/
-                - https://creativecommons.org/licenses/by/3.0/legalcode
-                - https://creativecommons.org/licenses/by-sa/3.0/legalcode
-                - https://creativecommons.org/licenses/by-nd/3.0/legalcode
-                - https://creativecommons.org/licenses/by-nc/3.0/legalcode
-                - https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode
-                - https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode
-                - http://cocina.sul.stanford.edu/licenses/none # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
     DROStructural:
       description: Structural metadata
       type: object


### PR DESCRIPTION
This reverts commit d463378fd0be61e8fe08fb602306dd8078ea2edb.

## Why was this change made?

We merged this before we have all the prod data ready for these new constraints.

## How was this change tested?



## Which documentation and/or configurations were updated?



