### PR TITLE
Revert "Revert "Bump cocina-models to 0.60.0""

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'action_policy'
 gem 'assembly-objectfile', '~> 1.9'
-gem 'cocina-models', '~> 0.59.0'
+gem 'cocina-models', '~> 0.60.0'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 6.33'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.59.1)
+    cocina-models (0.60.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -135,9 +135,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (6.34.0)
+    dor-services-client (6.35.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.59.0)
+      cocina-models (~> 0.60.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -413,7 +413,7 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.59.0)
+  cocina-models (~> 0.60.0)
   committee
   config (~> 2.0)
   dlss-capistrano (~> 3.6)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1069,6 +1069,37 @@ components:
             license:
               description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
               type: string
+              enum:
+                - https://www.gnu.org/licenses/agpl.txt
+                - https://www.apache.org/licenses/LICENSE-2.0
+                - https://opensource.org/licenses/BSD-2-Clause
+                - https://opensource.org/licenses/BSD-3-Clause
+                - https://creativecommons.org/licenses/by/4.0/legalcode
+                - https://creativecommons.org/licenses/by-nc/4.0/legalcode
+                - https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+                - https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+                - https://creativecommons.org/licenses/by-nd/4.0/legalcode
+                - https://creativecommons.org/licenses/by-sa/4.0/legalcode
+                - https://creativecommons.org/publicdomain/zero/1.0/legalcode
+                - https://opensource.org/licenses/cddl1
+                - https://www.eclipse.org/legal/epl-2.0
+                - https://www.gnu.org/licenses/gpl-3.0-standalone.html
+                - https://www.isc.org/downloads/software-support-policy/isc-license/
+                - https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+                - https://opensource.org/licenses/MIT
+                - https://www.mozilla.org/MPL/2.0/
+                - https://opendatacommons.org/licenses/by/1-0/
+                - http://opendatacommons.org/licenses/odbl/1.0/ # Non cannonical, but in some of our data
+                - https://opendatacommons.org/licenses/odbl/1-0/
+                - https://creativecommons.org/publicdomain/mark/1.0/
+                - https://opendatacommons.org/licenses/pddl/1-0/
+                - https://creativecommons.org/licenses/by/3.0/legalcode
+                - https://creativecommons.org/licenses/by-sa/3.0/legalcode
+                - https://creativecommons.org/licenses/by-nd/3.0/legalcode
+                - https://creativecommons.org/licenses/by-nc/3.0/legalcode
+                - https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode
+                - https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode
+                - http://cocina.sul.stanford.edu/licenses/none # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
     DROStructural:
       description: Structural metadata
       type: object


### PR DESCRIPTION


## Why was this change made?
This restores (#314) which was reverted in (#315) as we are now ready for this.
This reverts commit f5c14535d13c21f2ca696b1362a1f27c05e56ed5.


## How was this change tested?



## Which documentation and/or configurations were updated?



