### PR TITLE
Set the query_hash_key to avoid committee gem deprecation warnings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,10 +28,20 @@ module SdrApi
 
     # accept_request_filter omits OKComputer and Sidekiq
     accept_proc = proc { |request| request.path.start_with?('/v1') }
-    config.middleware.use Committee::Middleware::RequestValidation, schema_path: 'openapi.yml', strict: true,
-                                                                    accept_request_filter: accept_proc,
-                                                                    parse_response_by_content_type: false
-    config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
+    config.middleware.use(
+      Committee::Middleware::RequestValidation,
+      schema_path: 'openapi.yml',
+      strict: true,
+      accept_request_filter: accept_proc,
+      parse_response_by_content_type: false, # hush committee deprecation warning
+      query_hash_key: 'action_dispatch.request.query_parameters' # hush committee deprecation warning
+    )
+    config.middleware.use(
+      Committee::Middleware::ResponseValidation,
+      schema_path: 'openapi.yml',
+      parse_response_by_content_type: false, # hush committee deprecation warning
+      query_hash_key: 'action_dispatch.request.query_parameters' # hush committee deprecation warning
+    )
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
## Why was this change made?

This avoids a deprecation notice. Copied from the example at https://github.com/interagent/committee/blob/master/examples/openapi3_rails/config/application.rb#L44. 

Fixes #260

(Similar PRs: sul-dlss/dor-services-app/pull/2879 and sul-dlss/preservation_catalog/pull/1717, sul-dlss/technical-metadata-service/pull/259/files ).

## How was this change tested?

ran tests and didn't see warnings

## Which documentation and/or configurations were updated?



