### PR TITLE
Gemfile: simplecov no longer needs version restriction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rubocop'
   gem 'rubocop-rspec'
-  # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
-  gem 'simplecov', '~> 0.17.1', require: false
+  gem 'simplecov', require: false
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,6 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.6.1)
     json_schema (0.21.0)
     jwt (2.3.0)
     listen (3.7.0)
@@ -356,11 +355,12 @@ GEM
     sidekiq-statistic (1.4.0)
       sidekiq (>= 5.0)
       tilt (~> 2.0)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -424,7 +424,7 @@ DEPENDENCIES
   rubocop-rspec
   sidekiq (~> 6.0)
   sidekiq-statistic
-  simplecov (~> 0.17.1)
+  simplecov
   spring (~> 2.0)
   webmock
   whenever


### PR DESCRIPTION
## Why was this change made?

simpler Gemfile, more up to date simplecov

## How was this change tested?



## Which documentation and/or configurations were updated?



