### PR TITLE
Pass errors on to the client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -217,3 +217,8 @@ Rails/WhereExists: # new in 2.7
   Enabled: true
 Rails/WhereNot: # new in 2.8
   Enabled: true
+
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -62,6 +62,10 @@ class ResourcesController < ApplicationController
     cocina_obj = Dor::Services::Client.object(params[:id]).find
     authorize! cocina_obj, with: ResourcePolicy
     render json: cocina_obj
+  rescue Dor::Services::Client::NotFoundResponse => e
+    render build_error('404', e, "Object not found: #{params[:id]}")
+  rescue Dor::Services::Client::UnexpectedResponse => e
+    render build_error('500', e, 'Internal server error')
   end
 
   private

--- a/openapi.yml
+++ b/openapi.yml
@@ -140,6 +140,12 @@ paths:
                   - $ref: '#/components/schemas/DRO'
                   - $ref: '#/components/schemas/Collection'
                   - $ref: '#/components/schemas/AdminPolicy'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Unprocessable Entity
           content:

--- a/spec/requests/retrieve_resource_spec.rb
+++ b/spec/requests/retrieve_resource_spec.rb
@@ -3,76 +3,124 @@
 require 'rails_helper'
 
 RSpec.describe 'Retrieve a resource' do
-  let(:request) do
-    <<~JSON
-      {
-        "label":"hello",
-        "externalIdentifier":"druid:bc999dg9999",
-        "version":2,
-        "type":"#{Cocina::Models::Vocab.book}",
-        "description": {
-          "title": [{"value":"hello"}],
-          "purl": "https://purl.stanford.edu/bc999dg9999"
-        },
-        "access": {
-          "access":"world",
-          "copyright":"All rights reserved unless otherwise indicated.",
-          "download":"none",
-          "useAndReproductionStatement":"Property rights reside with the repository...",
-          "embargo": {
-            "releaseDate": "2029-06-22T07:00:00.000+00:00",
-            "access": "world",
-            "download": "world",
-            "useAndReproductionStatement": "Whatever you want"
-          }
-        },
-        "administrative": {
-          "hasAdminPolicy":"druid:bc123df4567",
-          "partOfProject":"Google Books",
-          "releaseTags":[]
-        },
-        "identification": {
-          "catalogLinks": [
-              {
-                "catalog":"symphony",
-                "catalogRecordId":"123456"
-              }
-          ],
-          "sourceId":"googlebooks:stanford_82323429"
-        },
-        #{structural}
-      }
-    JSON
+  context 'when happy path' do
+    let(:request) do
+      <<~JSON
+        {
+          "label":"hello",
+          "externalIdentifier":"druid:bc999dg9999",
+          "version":2,
+          "type":"#{Cocina::Models::Vocab.book}",
+          "description": {
+            "title": [{"value":"hello"}],
+            "purl": "https://purl.stanford.edu/bc999dg9999"
+          },
+          "access": {
+            "access":"world",
+            "copyright":"All rights reserved unless otherwise indicated.",
+            "download":"none",
+            "useAndReproductionStatement":"Property rights reside with the repository...",
+            "embargo": {
+              "releaseDate": "2029-06-22T07:00:00.000+00:00",
+              "access": "world",
+              "download": "world",
+              "useAndReproductionStatement": "Whatever you want"
+            }
+          },
+          "administrative": {
+            "hasAdminPolicy":"druid:bc123df4567",
+            "partOfProject":"Google Books",
+            "releaseTags":[]
+          },
+          "identification": {
+            "catalogLinks": [
+                {
+                  "catalog":"symphony",
+                  "catalogRecordId":"123456"
+                }
+            ],
+            "sourceId":"googlebooks:stanford_82323429"
+          },
+          #{structural}
+        }
+      JSON
+    end
+
+    let(:structural) do
+      <<~JSON
+        "structural":{
+          "isMemberOf":["druid:fg123hj4567"],
+          "contains":[
+            {
+              "type":"http://cocina.sul.stanford.edu/models/resources/file.jsonld",
+              "externalIdentifier":"9999",
+              "label":"Page 1",
+              "structural":{
+                "contains":[]
+              },
+              "version":2
+            }
+          ]
+        }
+      JSON
+    end
+
+    before do
+      stub_request(:get, 'http://localhost:3003/v1/objects/druid:bc999dg9999')
+        .to_return(status: 200, body: request, headers: {})
+    end
+
+    it 'returns the cocina model' do
+      get '/v1/resources/druid:bc999dg9999',
+          headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)['externalIdentifier']).to eq 'druid:bc999dg9999'
+    end
   end
 
-  let(:structural) do
-    <<~JSON
-      "structural":{
-        "isMemberOf":["druid:fg123hj4567"],
-        "contains":[
-          {
-            "type":"http://cocina.sul.stanford.edu/models/resources/file.jsonld",
-            "externalIdentifier":"9999",
-            "label":"Page 1",
-            "structural":{
-              "contains":[]
-            },
-            "version":2
-          }
-        ]
-      }
-    JSON
+  context 'when dor-services-client returns an unexpected response' do
+    let(:error_message) { 'Something really went wrong in DSA' }
+
+    before do
+      allow(Dor::Services::Client).to receive(:object).and_raise(
+        Dor::Services::Client::UnexpectedResponse,
+        error_message
+      )
+    end
+
+    it 'passes the error information along to the caller' do
+      get '/v1/resources/druid:bc999dg9999',
+          headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+      expect(response).not_to be_successful
+      expect(response).to have_http_status(:internal_server_error)
+      expect(JSON.parse(response.body)['errors'].first).to include(
+        'status' => '500',
+        'title' => 'Internal server error',
+        'detail' => error_message
+      )
+    end
   end
 
-  before do
-    stub_request(:get, 'http://localhost:3003/v1/objects/druid:bc999dg9999')
-      .to_return(status: 200, body: request, headers: {})
-  end
+  context 'when dor-services-client returns a not found response' do
+    let(:error_message) { 'Object not found: druid:bc999dg9999' }
 
-  it 'returns the cocina model' do
-    get '/v1/resources/druid:bc999dg9999',
-        headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
-    expect(response).to be_successful
-    expect(JSON.parse(response.body)['externalIdentifier']).to eq 'druid:bc999dg9999'
+    before do
+      allow(Dor::Services::Client).to receive(:object).and_raise(
+        Dor::Services::Client::NotFoundResponse,
+        error_message
+      )
+    end
+
+    it 'passes the error information along to the caller' do
+      get '/v1/resources/druid:bc999dg9999',
+          headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+      expect(response).not_to be_successful
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)['errors'].first).to include(
+        'status' => '404',
+        'title' => error_message,
+        'detail' => error_message
+      )
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

While working on https://github.com/sul-dlss/sdr-client/issues/184, I found that passing bogus druids via the CLI resulted in a blank response. As a CLI user, I found that unclear. This commit allows SDR API to pass more context back to clients in the event of errors, at least when fulfulling a resource show request.

## How was this change tested? 🤨

CI (should not affect happy path operation)
