### PR TITLE
update_job: send version params when opening a new version

### DIFF
--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -51,7 +51,7 @@ class UpdateJob < ApplicationJob
         object_client.accession.start(versioning_params.merge(workflow: 'accessionWF'))
       elsif model.version == existing.version + 1
         # don't kick off accessioning, just create a new version where only metadata was updated
-        object_client.version.open
+        object_client.version.open(versioning_params)
         object_client.version.close(versioning_params.merge(start_accession: false))
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Goes with PR sul-dlss/dor-services-app#3921;  the description and significance params should be passed upon opening a version

## How was this change tested? 🤨

specs and integration specs for H2 and preassembly, both of which use the affected service.

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



