### PR TITLE
Start simplecov before requiring the environment

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,13 +4,13 @@
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 
+require 'simplecov'
+SimpleCov.start 'rails'
+
 require File.expand_path('../config/environment', __dir__)
 
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
-
-require 'simplecov'
-SimpleCov.start 'rails'
 
 require 'rspec/rails'
 require 'webmock/rspec'


### PR DESCRIPTION
## Why was this change made? 🤔
Because we're eager loading in the test environment.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



