### PR TITLE
Add a parameter for providing a priority to the request

### DIFF
--- a/app/services/workflow.rb
+++ b/app/services/workflow.rb
@@ -2,12 +2,15 @@
 
 # Methods for interfacing with the workflow service
 class Workflow
-  def self.create_unless_exists(druid, workflow_name, version: 1)
+  # @param [String] druid
+  # @param [String] workflow_name
+  # @param [Integer] version (1)
+  # @param [String] priority ('default') determines the relative priority used for the workflow.
+  #                                      Value may be 'low' or 'default'
+  def self.create_unless_exists(druid, workflow_name, version: 1, priority: 'default')
     return unless workflow_client.workflow(pid: druid, workflow_name: workflow_name).empty?
 
-    # Setting lane_id to low for all, which is appropriate for all current use cases. In the future, may want to make
-    # this an API parameter.
-    workflow_client.create_workflow_by_name(druid, workflow_name, version: version, lane_id: 'low')
+    workflow_client.create_workflow_by_name(druid, workflow_name, version: version, lane_id: priority)
   end
 
   def self.workflow_client

--- a/openapi.yml
+++ b/openapi.yml
@@ -107,8 +107,16 @@ paths:
       parameters:
         - in: query
           name: accession
+          description: If set to true the accessioning workflow will be started
           schema:
             type: boolean
+        - in: query
+          name: priority
+          schema:
+            type: string
+            enum:
+              - 'default'
+              - 'low'          
         - in: query
           name: assign_doi
           schema:

--- a/spec/requests/create_resource_spec.rb
+++ b/spec/requests/create_resource_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'Create a resource' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: [],
                                                               start_workflow: false,
-                                                              assign_doi: false)
+                                                              assign_doi: false,
+                                                              priority: 'default')
     end
   end
 
@@ -84,18 +85,21 @@ RSpec.describe 'Create a resource' do
       model_params.with_indifferent_access
     end
 
-    it 'registers the resource and kicks off IngestJob' do
-      post '/v1/resources',
-           params: request,
-           headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to be_created
-      expect(response.location).to be_present
-      expect(JSON.parse(response.body)['jobId']).to be_present
-      expect(IngestJob).to have_received(:perform_later).with(model_params: expected_model_params,
-                                                              background_job_result: instance_of(BackgroundJobResult),
-                                                              signed_ids: [signed_id],
-                                                              start_workflow: false,
-                                                              assign_doi: false)
+    context 'when priority is not provided' do
+      it 'registers the resource and kicks off IngestJob' do
+        post '/v1/resources',
+             params: request,
+             headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to be_created
+        expect(response.location).to be_present
+        expect(JSON.parse(response.body)['jobId']).to be_present
+        expect(IngestJob).to have_received(:perform_later).with(model_params: expected_model_params,
+                                                                background_job_result: instance_of(BackgroundJobResult),
+                                                                signed_ids: [signed_id],
+                                                                start_workflow: false,
+                                                                assign_doi: false,
+                                                                priority: 'default')
+      end
     end
 
     context 'when wrong version of cocina models is supplied' do
@@ -113,6 +117,20 @@ RSpec.describe 'Create a resource' do
       end
     end
 
+    context 'when the priority flag is set to low' do
+      it 'kicks off accession workflow' do
+        post '/v1/resources?accession=true&priority=low',
+             params: request,
+             headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+        expect(IngestJob).to have_received(:perform_later).with(model_params: expected_model_params,
+                                                                background_job_result: instance_of(BackgroundJobResult),
+                                                                signed_ids: [signed_id],
+                                                                start_workflow: true,
+                                                                assign_doi: false,
+                                                                priority: 'low')
+      end
+    end
+
     context 'when the accession flag is set to true' do
       it 'kicks off accession workflow' do
         post '/v1/resources?accession=true',
@@ -122,7 +140,8 @@ RSpec.describe 'Create a resource' do
                                                                 background_job_result: instance_of(BackgroundJobResult),
                                                                 signed_ids: [signed_id],
                                                                 start_workflow: true,
-                                                                assign_doi: false)
+                                                                assign_doi: false,
+                                                                priority: 'default')
       end
     end
 
@@ -135,7 +154,8 @@ RSpec.describe 'Create a resource' do
                                                                 background_job_result: instance_of(BackgroundJobResult),
                                                                 signed_ids: [signed_id],
                                                                 start_workflow: false,
-                                                                assign_doi: false)
+                                                                assign_doi: false,
+                                                                priority: 'default')
       end
     end
 
@@ -148,7 +168,8 @@ RSpec.describe 'Create a resource' do
                                                                 background_job_result: instance_of(BackgroundJobResult),
                                                                 signed_ids: [signed_id],
                                                                 start_workflow: false,
-                                                                assign_doi: true)
+                                                                assign_doi: true,
+                                                                priority: 'default')
       end
     end
 


### PR DESCRIPTION
This gets passed on to the workflow as 'lane'.  This will allow us to give h2 requests a default priority and Google Books a low priority.

## Why was this change made? 🤔

We recently reduced the number of preservation robots workers so as not to overload Ceph.  This caused a queue to build up and h2 deposits got stuck behind google books deposits, leading to a degraded user experience.

## How was this change tested? 🤨
CI
