### PR TITLE
Adds support for setting version description on update.

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -34,7 +34,6 @@ class ResourcesController < ApplicationController
            status: :created
   end
   # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/MethodLength
 
   # PUT /resource/:id
   def update
@@ -50,12 +49,14 @@ class ResourcesController < ApplicationController
     result = BackgroundJobResult.create(output: {})
     UpdateJob.perform_later(model_params: JSON.parse(cocina_dro.to_json), # Needs to be sidekiq friendly serialization
                             signed_ids: signed_ids(params),
+                            version_description: params[:versionDescription],
                             background_job_result: result)
 
     render json: { jobId: result.id },
            location: result,
            status: :accepted
   end
+  # rubocop:enable Metrics/MethodLength
 
   # This just proxies the response from DOR services app
   def show
@@ -77,7 +78,7 @@ class ResourcesController < ApplicationController
   end
 
   def cocina_update_params
-    params.except(:action, :controller, :resource, :id).to_unsafe_h
+    params.except(:action, :controller, :resource, :id, :versionDescription).to_unsafe_h
   end
 
   def validate_version

--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -12,9 +12,10 @@ class UpdateJob < ApplicationJob
   # @param [Array<String>] signed_ids for the blobs
   # @param [BackgroundJobResult] background_job_result
   # @param [Boolean] start_workflow starts accessionWF if true; if false, opens/closes new version without accessioning
+  # @param [String] version_description
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
-  def perform(model_params:, signed_ids:, background_job_result:, start_workflow: true)
+  def perform(model_params:, signed_ids:, background_job_result:, start_workflow: true, version_description: nil)
     # Increment the try count
     background_job_result.try_count += 1
     background_job_result.processing!
@@ -42,7 +43,7 @@ class UpdateJob < ApplicationJob
 
     background_job_result.output = { druid: model.externalIdentifier }
 
-    versioning_params = { description: 'Update via sdr-api', significance: 'major' }
+    versioning_params = { description: version_description || 'Update via sdr-api', significance: 'major' }
 
     StageFiles.stage(signed_ids, model.externalIdentifier) do
       if start_workflow

--- a/openapi.yml
+++ b/openapi.yml
@@ -199,6 +199,10 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: versionDescription
+          in: query          
+          schema:
+            type: string
       requestBody:
         description: The metadata for the object
         required: true

--- a/spec/jobs/update_job_spec.rb
+++ b/spec/jobs/update_job_spec.rb
@@ -91,12 +91,13 @@ RSpec.describe UpdateJob, type: :job do
     end
 
     it 'accessions an object by default without explicitly opening/closing a version' do
-      described_class.perform_now(model_params: model, background_job_result: result, signed_ids: signed_ids)
+      described_class.perform_now(model_params: model, background_job_result: result, signed_ids: signed_ids,
+                                  version_description: 'Updated metadata')
       expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
       expect(version_client).not_to have_received(:open)
       expect(version_client).not_to have_received(:close)
       expect(accession_client).to have_received(:start)
-        .with(description: 'Update via sdr-api', significance: 'major', workflow: 'accessionWF')
+        .with(description: 'Updated metadata', significance: 'major', workflow: 'accessionWF')
     end
 
     it 'opens and closes the version without kicking off accessioning if start_workflow is false' do

--- a/spec/requests/update_resource_spec.rb
+++ b/spec/requests/update_resource_spec.rb
@@ -64,13 +64,14 @@ RSpec.describe 'Update a resource' do
     # NOTE: These params are expected when a request expects sdr-api NOT to manage files on its behalf
     dro.to_h.with_indifferent_access
   end
+  let(:version_description) { 'Updated metadata' }
 
   before do
     allow(UpdateJob).to receive(:perform_later)
   end
 
   it 'registers the resource and kicks off UpdateJob' do
-    put '/v1/resources/druid:bc999dg9999',
+    put "/v1/resources/druid:bc999dg9999?versionDescription=#{version_description}",
         params: request,
         headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
 
@@ -79,7 +80,8 @@ RSpec.describe 'Update a resource' do
     expect(JSON.parse(response.body)['jobId']).to be_present
     expect(UpdateJob).to have_received(:perform_later).with(model_params: expected_model_params_without_file_ids,
                                                             background_job_result: instance_of(BackgroundJobResult),
-                                                            signed_ids: [file_id])
+                                                            signed_ids: [file_id],
+                                                            version_description: version_description)
   end
 
   context 'when wrong version of cocina models is supplied' do
@@ -122,7 +124,7 @@ RSpec.describe 'Update a resource' do
       expect(JSON.parse(response.body)['jobId']).to be_present
       expect(UpdateJob).to have_received(:perform_later).with(model_params: expected_model_params_with_file_ids,
                                                               background_job_result: instance_of(BackgroundJobResult),
-                                                              signed_ids: [])
+                                                              signed_ids: [], version_description: nil)
     end
   end
 
@@ -138,7 +140,7 @@ RSpec.describe 'Update a resource' do
       expect(JSON.parse(response.body)['jobId']).to be_present
       expect(UpdateJob).to have_received(:perform_later).with(model_params: expected_model_params_with_file_ids,
                                                               background_job_result: instance_of(BackgroundJobResult),
-                                                              signed_ids: [])
+                                                              signed_ids: [], version_description: nil)
     end
   end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/happy-heron/issues/2090

## Why was this change made? 🤔
So that it can be passed by H2.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

