### PR TITLE
update openapi.yml and gems for cocina-models 0.84.0 (DOI exceptions)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'action_policy'
 gem 'assembly-objectfile', '~> 2.0'
-gem 'cocina-models', '~> 0.83.0'
+gem 'cocina-models', '~> 0.84.0'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.83.0)
+    cocina-models (0.84.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -148,9 +148,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (12.6.0)
+    dor-services-client (12.7.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.83.0)
+      cocina-models (~> 0.84.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -403,6 +403,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-21
   x86_64-linux
 
@@ -415,7 +416,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-rvm
-  cocina-models (~> 0.83.0)
+  cocina-models (~> 0.84.0)
   committee
   config (~> 2.0)
   dlss-capistrano

--- a/openapi.yml
+++ b/openapi.yml
@@ -116,7 +116,7 @@ paths:
             type: string
             enum:
               - 'default'
-              - 'low'          
+              - 'low'
         - in: query
           name: assign_doi
           schema:
@@ -200,7 +200,7 @@ paths:
           schema:
             $ref: '#/components/schemas/Druid'
         - name: versionDescription
-          in: query          
+          in: query
           schema:
             type: string
       requestBody:
@@ -1020,9 +1020,18 @@ components:
               # description: An alphabet or other notation used to represent a
               #   language or other symbolic system of the descriptive element value.
     DOI:
-      type: string
       description: Digital Object Identifier (https://www.doi.org)
-      # The prod and test prefixes are permitted
+      oneOf:
+        - $ref: '#/components/schemas/DoiPattern'
+        - $ref: '#/components/schemas/DoiExceptions'
+    DoiExceptions:
+      type: string
+      description: pre-existing Digital Object Identifiers (https://www.doi.org) not matching the pattern (case insensitive)
+      pattern: '^10\.(25740\/([vV][aA]90-[cC][tT]15|[sS][yY][xX][aA]-[mM]256|12[qQ][fF]-5243|65[jJ]8-6114)|25936\/629[tT]-[bB][xX]79)$'
+      example: '10.25740/12qF-5243'
+    DoiPattern:
+      type: string
+      description: Digital Object Identifier (https://www.doi.org) regex pattern      # The prod and test prefixes are permitted
       pattern: '^10\.(25740|80343)\/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
       example: '10.25740/bc123df4567'
     DRO:


### PR DESCRIPTION
## Why was this change made? 🤔

To use cocina-models that accommodate the DOI exceptions.  And to be in sync.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



