### PR TITLE
Align the file_ids generated on update with DSA generated ids

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -72,6 +72,7 @@ class ResourcesController < ApplicationController
   private
 
   CREATE_PARAMS_EXCLUDE_FROM_COCINA = %i[action controller resource accession priority assign_doi].freeze
+  ID_NAMESPACE = 'https://cocina.sul.stanford.edu'
 
   def cocina_create_params
     params.except(*CREATE_PARAMS_EXCLUDE_FROM_COCINA).to_unsafe_h
@@ -114,10 +115,14 @@ class ResourcesController < ApplicationController
         next unless signed_id?(file[:externalIdentifier])
 
         decorate_file(file: file,
-                      external_id: "#{model_params[:externalIdentifier]}/#{file[:filename]}",
+                      external_id: file_identifier(model_params[:externalIdentifier], fileset[:externalIdentifier]),
                       version: model_params[:version])
       end
     end
+  end
+
+  def file_identifier(object_id, resource_id)
+    "#{ID_NAMESPACE}/file/#{object_id.delete_prefix('druid:')}-#{resource_id}/#{SecureRandom.uuid}"
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/spec/requests/update_resource_spec.rb
+++ b/spec/requests/update_resource_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Update a resource' do
       file_params.delete(:externalIdentifier)
       file_params[:hasMimeType] = 'application/octet-stream'
       file_params[:size] = 10
-      file_params[:externalIdentifier] = 'druid:bc999dg9999/file2.txt'
+      file_params[:externalIdentifier] = 'https://cocina.sul.stanford.edu/file/bc999dg9999-9999/ffef5496-7b89-4df6-b8c0-de37805a43ec'
     end
   end
   let(:expected_model_params_with_file_ids) do
@@ -68,6 +68,7 @@ RSpec.describe 'Update a resource' do
 
   before do
     allow(UpdateJob).to receive(:perform_later)
+    allow(SecureRandom).to receive(:uuid).and_return('ffef5496-7b89-4df6-b8c0-de37805a43ec')
   end
 
   it 'registers the resource and kicks off UpdateJob' do


### PR DESCRIPTION


## Why was this change made? 🤔
We want file ids that come from SDR-API to be of the same format (URI) that are generated by DSA itself.
Fixes #492


## How was this change tested? 🤨
CI
