### PR TITLE
Change strategy for determining if a file is activestorage or existing.

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -178,13 +178,12 @@ class ResourcesController < ApplicationController
   # amend an item's APO. This operation does not require sdr-api to handle files
   # and is merely passing through Cocina to SDR. One way we can tell whether a Cocina
   # structure depends on sdr-api to manage files is by sniffing files' external
-  # identifiers. If the external identifier of a file is a legitimate HTTP(S) URI,
-  # SDR already has a file on hand for the object, and sdr-api can simply pass through
-  # the structure undecorated. If on the other hand the external identifier is not
-  # an HTTP(S) URI, that is a signal that the originating user or system expects
-  # the API to manage files for them.
+  # identifiers. If the external identifier of a file is a legitimate signed id,
+  # the originating user or system expects the API to manage files for them. On the
+  # other hand, it can be assumed that SDR already has a file on hand for the object,
+  # and sdr-api can simply pass through the structure undecorated.
   def signed_id?(file_id)
-    !file_id.match?(%r{^https?://})
+    ActiveStorage.verifier.valid_message?(file_id)
   end
 
   def base64_to_hexdigest(base64)

--- a/spec/requests/update_resource_spec.rb
+++ b/spec/requests/update_resource_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe 'Update a resource' do
   context 'when blob not found for file' do
     let(:file_id) { 'abc123' }
 
+    before do
+      allow(ActiveStorage.verifier).to receive(:valid_message?).and_return(true)
+    end
+
     it 'returns 500' do
       put '/v1/resources/druid:bc123df4567',
           params: request,


### PR DESCRIPTION
closes #493

## Why was this change made? 🤔
To more accurately determine if file is in activestorage or existing in SDR.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, QA

