### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -38,7 +38,6 @@ require 'capistrano/honeybadger'
 require 'capistrano/rails/migrations'
 require 'dlss/capistrano'
 require 'whenever/capistrano'
-require 'capistrano/rvm'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,5 @@ end
 group :deployment do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
-  gem 'capistrano-rvm', require: false
   gem 'dlss-capistrano', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,9 +104,6 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     cocina-models (0.84.4)
@@ -415,7 +412,6 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   cocina-models (~> 0.84.0)
   committee
   config (~> 2.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -48,7 +48,3 @@ set :sidekiq_systemd_use_hooks, true
 
 # Update shared_configs as part of deployment process
 before 'deploy:restart', 'shared_configs:update'
-
-# the honeybadger gem should integrate automatically with capistrano-rvm but it
-# doesn't appear to do so on our new Ubuntu boxes :shrug:
-set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')


### PR DESCRIPTION
## Why was this change made? 🤔

This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.


## How was this change tested? 🤨

Deployed to stage as a test and it worked just fine.
