### PR TITLE
update to cocina-models 0.85.0; update openapi.yml to remove parallelContributor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'action_policy'
 gem 'assembly-objectfile', '~> 2.0'
-gem 'cocina-models', '~> 0.84.0'
+gem 'cocina-models', '~> 0.85.0'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.84.5)
+    cocina-models (0.85.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -145,9 +145,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (12.7.0)
+    dor-services-client (12.8.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.84.0)
+      cocina-models (~> 0.85.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -412,7 +412,7 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.84.0)
+  cocina-models (~> 0.85.0)
   committee
   config (~> 2.0)
   dlss-capistrano

--- a/openapi.yml
+++ b/openapi.yml
@@ -674,11 +674,6 @@ components:
         valueAt:
           description: URL or other pointer to the location of the contributor information.
           type: string
-        parallelContributor:
-          description: For multiple representations of information about the same contributor (e.g. in different languages).
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveParallelContributor"
     ControlledDigitalLendingAccess:
       type: object
       properties:
@@ -902,44 +897,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
-    DescriptiveParallelContributor:
-      description: Value model for multiple representations of information about the same contributor (e.g. in different languages).
-      deprecated: true
-      type: object
-      additionalProperties: false
-      properties:
-        name:
-          description: Names associated with a contributor.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        type:
-          description: Entity type of the contributor (person, organization, etc.).
-          type: string
-        status:
-          description: Status of the contributor relative to other parallel contributors (e.g. the primary author among a group of contributors).
-          type: string
-        role:
-          description: Relationships of the contributor to the resource or to an event in its history.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        identifier:
-          description: Identifiers and URIs associated with the contributor entity.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        note:
-          description: Other information associated with the contributor.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        valueAt:
-          description: URL or other pointer to the location of the contributor information.
-          type: string
-        valueLanguage:
-          # description: Language of the descriptive element value
-          $ref: "#/components/schemas/DescriptiveValueLanguage"
     DescriptiveParallelEvent:
       description: Value model for multiple representations of information about the same event (e.g. in different languages).
       type: object


### PR DESCRIPTION
## Why was this change made? 🤔

Removing usused parallelContributor from cocina-models and thus this API; using updated cocina-models gem with this change, and dor-services-client as well.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



