### PR TITLE
Removed assembly-objectfile gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'pg'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'action_policy'
-gem 'assembly-objectfile', '~> 2.0'
 gem 'cocina-models', '~> 0.86.0'
 gem 'committee'
 gem 'config', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,10 +72,6 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    assembly-objectfile (2.1.3)
-      activesupport (>= 5.2.0)
-      mime-types (> 3)
-      mini_exiftool
     ast (2.4.2)
     attr_extras (6.2.5)
     bcrypt (3.1.18)
@@ -237,10 +233,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
-    mini_exiftool (2.10.2)
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.6.0)
@@ -398,7 +390,6 @@ PLATFORMS
 
 DEPENDENCIES
   action_policy
-  assembly-objectfile (~> 2.0)
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug


### PR DESCRIPTION
## Why was this change made? 🤔
It isn't used.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



