### PR TITLE
Create valid file externalIdentifiers that match a fileSet

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -117,14 +117,29 @@ class ResourcesController < ApplicationController
         next unless signed_id?(file[:externalIdentifier])
 
         decorate_file(file: file,
-                      external_id: file_identifier(model_params[:externalIdentifier], fileset[:externalIdentifier]),
-                      version: model_params[:version])
+                      version: model_params[:version],
+                      external_id: file_identifier(model_params[:externalIdentifier],
+                                                   choose_resource_id(fileset[:externalIdentifier])))
       end
     end
   end
 
+  def valid_fileset_id?(external_id)
+    external_id.start_with?("#{ID_NAMESPACE}/fileSet/")
+  end
+
+  def choose_resource_id(external_id)
+    # take the uuid from a valid fileset ID or create a uuid
+    valid_fileset_id?(external_id) ? get_fileset_uuid(external_id) : external_id
+  end
+
   def file_identifier(object_id, resource_id)
     "#{ID_NAMESPACE}/file/#{object_id.delete_prefix('druid:')}-#{resource_id}/#{SecureRandom.uuid}"
+  end
+
+  def get_fileset_uuid(external_id)
+    # get the uuid (012345) from a valid externalIdentifier such as https://cocina.sul.stanford.edu/fileSet/px880kw6696-012345
+    external_id.split("#{ID_NAMESPACE}/fileSet/").second.split('-', 2).second
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/spec/requests/update_resource_spec.rb
+++ b/spec/requests/update_resource_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Update a resource' do
       'contains' => [
         {
           'type' => Cocina::Models::FileSetType.file,
-          'externalIdentifier' => '9999',
+          'externalIdentifier' => fileset_id,
           'label' => 'Page 1',
           'structural' => {
             'contains' => [
@@ -47,6 +47,7 @@ RSpec.describe 'Update a resource' do
     ActiveStorage::Blob.create!(key: 'tozuehlw6e8du20vn1xfzmiifyok',
                                 filename: 'file2.txt', byte_size: 10, checksum: checksum)
   end
+  let(:fileset_id) { '9999' }
   let(:file_id) do
     ActiveStorage.verifier.generate(blob.id, purpose: :blob_id)
   end
@@ -146,6 +147,33 @@ RSpec.describe 'Update a resource' do
       expect(UpdateJob).to have_received(:perform_later).with(model_params: expected_model_params_with_file_ids,
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: {}, version_description: nil)
+    end
+  end
+
+  context 'when fileset ID is an HTTPS URI' do
+    let(:fileset_id) { 'https://cocina.sul.stanford.edu/fileSet/bc999dg9999-9999999' }
+    let(:expected_model_params_without_file_ids) do
+      # NOTE: These params are expected when a request expects sdr-api to manage files on its behalf
+      expected_model_params_with_file_ids.dup.tap do |model_params|
+        file_params = model_params[:structural][:contains][0][:structural][:contains][0]
+        file_params.delete(:externalIdentifier)
+        file_params[:hasMimeType] = 'application/octet-stream'
+        file_params[:size] = 10
+        file_params[:externalIdentifier] = 'https://cocina.sul.stanford.edu/file/bc999dg9999-9999999/ffef5496-7b89-4df6-b8c0-de37805a43ec'
+      end
+    end
+
+    it 'registers the resource and kicks off UpdateJob' do
+      put '/v1/resources/druid:bc999dg9999',
+          params: request,
+          headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_accepted
+      expect(response.location).to be_present
+      expect(JSON.parse(response.body)['jobId']).to be_present
+      expect(UpdateJob).to have_received(:perform_later).with(model_params: expected_model_params_without_file_ids,
+                                                              background_job_result: instance_of(BackgroundJobResult),
+                                                              signed_ids: { 'file2.txt' => file_id },
+                                                              version_description: nil)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
If sdr-api gets a signed_id from h2 and a cocina-namespaced fileSet identifier, it needs to create a file identifier so that includes the fileSet identifier's UUID. This scenario occurs in creating a second version of a work in h2 and adding a file, or in reserving a PURL and then adding files on deposit. 

## How was this change tested? 🤨
Unit tests and integration tests on QA.

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



