### PR TITLE
Async digest generation for Globus deposits

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -160,11 +160,11 @@ class ResourcesController < ApplicationController
     raise GlobusNotFoundError, "Globus file [#{globus_file}] not found." unless File.exist?(globus_file)
 
     file[:size] = File.size(globus_file)
-    file[:hasMessageDigests] = [
-      { type: 'md5', digest: Digest::MD5.file(globus_file).hexdigest },
-      { type: 'sha1', digest: Digest::SHA1.file(globus_file).hexdigest }
-    ]
     file[:hasMimeType] = Marcel::MimeType.for Pathname.new(globus_file)
+    # file[:hasMessageDigests] are not calculated here since they could take
+    # some time to generate when processing deposits with large files. Instead
+    # digest generation happens in the asynchronous IngestJob or UpdateJob to
+    # avoid a long HTTP response.
   end
 
   def decorate_blob(file)

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -24,6 +24,7 @@ class IngestJob < ApplicationJob
     background_job_result.try_count += 1
     background_job_result.processing!
     model = Cocina::Models.build_request(model_params.with_indifferent_access)
+    model = GlobusDigestGenerator.generate(cocina: model, globus_ids: globus_ids)
     begin
       response_cocina_obj = Dor::Services::Client.objects.register(params: model, assign_doi: assign_doi)
       druid = response_cocina_obj.externalIdentifier

--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -51,7 +51,10 @@ class UpdateJob < ApplicationJob
       return
     end
 
-    # Note that not using a lock here since all model params are being provided rather than updating retrieved params.
+    # globus deposits may not have digests yet and they need to be generated before staging (copy)
+    model = GlobusDigestGenerator.generate(cocina: model, globus_ids: globus_ids)
+
+    # not using a lock here since all model params are being provided rather than updating retrieved params.
     object_client.update(params: model, skip_lock: true)
 
     background_job_result.output = { druid: model.externalIdentifier }
@@ -87,7 +90,7 @@ class UpdateJob < ApplicationJob
                                                                                  message: e.message] })
     background_job_result.complete!
   end
-  # rubocop:enable  Metrics/ParameterLists
+  # rubocop:enable Metrics/ParameterLists
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
 

--- a/app/services/globus_digest_generator.rb
+++ b/app/services/globus_digest_generator.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# GlobusDigestGenerator
+#
+# Add digests to Globus DROs if the files currently lack them. Existing files
+# will not be overwritten.
+class GlobusDigestGenerator
+  # @param [Cocina::Model] cocina a DRO to add digests to
+  # @param [Hash] globus_ids a mapping of filenames to their location on disk
+  # @return [Cocina::Model] a new Cocina object with (potentially) new digests
+  def self.generate(cocina:, globus_ids:)
+    new(cocina: cocina, globus_ids: globus_ids).generate
+  end
+
+  def initialize(cocina:, globus_ids:)
+    @cocina = cocina
+    @globus_ids = globus_ids
+  end
+
+  def generate
+    return cocina if !cocina.dro? || globus_ids.blank?
+
+    props = cocina.to_h
+    props[:structural] = generate_filesets(props[:structural])
+
+    if cocina.is_a? Cocina::Models::RequestDRO
+      Cocina::Models.build_request(props)
+    else
+      Cocina::Models.build(props)
+    end
+  end
+
+  private
+
+  attr_reader :cocina, :globus_ids
+
+  def generate_filesets(filesets)
+    filesets[:contains] = filesets[:contains].map do |fileset|
+      generate_files(fileset)
+    end
+
+    filesets
+  end
+
+  def generate_files(fileset)
+    fileset[:structural][:contains] = fileset[:structural][:contains].map do |file|
+      generate_digests(file)
+    end
+
+    fileset
+  end
+
+  def generate_digests(file)
+    # only generate digests for a file if it doesn't have any
+    if file[:hasMessageDigests].blank? && globus_ids.key?(file[:filename])
+      file_path = globus_ids[file[:filename]].sub(%r{^globus://}, Settings.globus_location)
+      file[:hasMessageDigests] = [
+        { type: 'sha1', digest: Digest::SHA1.file(file_path).hexdigest },
+        { type: 'md5', digest: Digest::MD5.file(file_path).hexdigest }
+      ]
+    end
+
+    file
+  end
+end

--- a/app/services/stage_globus.rb
+++ b/app/services/stage_globus.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Moves files from the ActiveStorage to the staging mount
+# Moves files from the Globus storage to the staging mount
 # @param [Hash] globus_ids a mapping of filenames to their location on disk
 # @param [String] druid
 # @return [Integer] the number of files staged

--- a/spec/requests/create_dro_spec.rb
+++ b/spec/requests/create_dro_spec.rb
@@ -178,10 +178,6 @@ RSpec.describe 'Create a DRO' do
       model_params = dro.to_h
       file_params = model_params.dig(:structural, :contains, 0, :structural, :contains, 0)
       file_params[:size] = 5
-      file_params[:hasMessageDigests] = [
-        { 'digest' => md5, 'type' => 'md5' },
-        { 'digest' => sha1, 'type' => 'sha1' }
-      ]
       file_params[:hasMimeType] = 'application/octet-stream'
       model_params.with_indifferent_access
     end

--- a/spec/services/globus_digest_generator_spec.rb
+++ b/spec/services/globus_digest_generator_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GlobusDigestGenerator do
+  let(:structural) do
+    {
+      'isMemberOf' => ['druid:fg123hj4567'],
+      'contains' => [
+        {
+          'type' => Cocina::Models::FileSetType.file,
+          'externalIdentifier' => '999',
+          'label' => 'Page 1',
+          'structural' => {
+            'contains' => [
+              {
+                'type' => Cocina::Models::ObjectType.file,
+                'filename' => '00001.jp2',
+                'label' => '00001.jp2',
+                'hasMessageDigests' => [],
+                'externalIdentifier' => 'abc123',
+                'version' => 1
+              },
+              {
+                'type' => Cocina::Models::ObjectType.file,
+                'filename' => '00002.jp2',
+                'label' => '00002.jp2',
+                'hasMessageDigests' => [],
+                'externalIdentifier' => 'abc123',
+                'version' => 1
+              },
+              {
+                'type' => Cocina::Models::ObjectType.file,
+                'filename' => '00003.jp2',
+                'label' => '00002.jp2',
+                'hasMessageDigests' => [
+                  {
+                    'type' => 'sha1',
+                    'digest' => 'not-a-real-sha1'
+                  },
+                  {
+                    'type' => 'md5',
+                    'digest' => 'not-a-real-md5'
+                  }
+                ],
+                'externalIdentifier' => 'abc123',
+                'version' => 1
+              }
+            ]
+          },
+          'version' => 1
+        }
+      ]
+    }
+  end
+
+  let(:dro) { build(:dro, id: 'druid:bc999dg9999').new(structural: structural) }
+
+  describe '#generate' do
+    let(:new_dro) { described_class.generate(cocina: dro, globus_ids: globus_ids) }
+    let(:files) { new_dro.structural.contains[0].structural.contains }
+    let(:globus_ids) do
+      {
+        '00001.jp2' => 'globus://test/00001.jp2',
+        '00002.jp2' => 'globus://test/00002.jp2'
+      }
+    end
+
+    before do
+      FileUtils.rm_rf('tmp/globus/test')
+      FileUtils.cp_r('spec/fixtures', 'tmp/globus/test')
+    end
+
+    it 'populates missing digests' do
+      expect(files[0].hasMessageDigests[0].type).to eq 'sha1'
+      expect(files[0].hasMessageDigests[0].digest).to eq 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+      expect(files[0].hasMessageDigests[1].type).to eq 'md5'
+      expect(files[0].hasMessageDigests[1].digest).to eq 'd41d8cd98f00b204e9800998ecf8427e'
+
+      expect(files[1].hasMessageDigests[0].type).to eq 'sha1'
+      expect(files[1].hasMessageDigests[0].digest).to eq 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+      expect(files[1].hasMessageDigests[1].type).to eq 'md5'
+      expect(files[1].hasMessageDigests[1].digest).to eq 'd41d8cd98f00b204e9800998ecf8427e'
+    end
+
+    it 'leaves pre-existing digests alone' do
+      expect(files[2].hasMessageDigests[0].type).to eq 'sha1'
+      expect(files[2].hasMessageDigests[0].digest).to eq 'not-a-real-sha1'
+      expect(files[2].hasMessageDigests[1].type).to eq 'md5'
+      expect(files[2].hasMessageDigests[1].digest).to eq 'not-a-real-md5'
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

`GlobusDigestGenerator` will generate digests for Globus deposits if the files currently lack them. It is used during the asynchronous Sidekiq jobs (`UpdateJob` and `IngestJob`) instead of during HTTP response generation when a Resource is created or updated. This means that large files won't cause the HTTP responses to take a long time and risk timeout.

See https://github.com/sul-dlss/happy-heron/issues/2995 for additional context about why this is needed.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



