### PR TITLE
Ensure AccessionWF is kicked off once

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -48,13 +48,10 @@ class IngestJob < ApplicationJob
     # Create workflow destroys existing steps if called again, so need to check if already created.
     Workflow.create_unless_exists(druid, 'registrationWF', version: 1, priority: priority)
 
-    StageBlobs.stage(signed_ids, druid) do
-      Workflow.create_unless_exists(druid, 'accessionWF', version: 1, priority: priority) if start_workflow
-    end
+    StageBlobs.stage(signed_ids, druid)
+    StageGlobus.stage(globus_ids, druid)
 
-    StageGlobus.stage(globus_ids, druid) do
-      Workflow.create_unless_exists(druid, 'accessionWF', version: 1, priority: priority) if start_workflow
-    end
+    Workflow.create_unless_exists(druid, 'accessionWF', version: 1, priority: priority) if start_workflow
 
     background_job_result.complete!
   rescue StandardError => e

--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -12,6 +12,7 @@ class UpdateJob < ApplicationJob
 
   # @param [Hash] model_params
   # @param [Hash] filename, signed_ids for the blobs
+  # @param [Hash] filename, globus_ids for the staged Globus files
   # @param [BackgroundJobResult] background_job_result
   # @param [Boolean] start_workflow starts accessionWF if true; if false, opens/closes new version without accessioning
   # @param [String] version_description
@@ -57,13 +58,10 @@ class UpdateJob < ApplicationJob
 
     versioning_params = { description: version_description || 'Update via sdr-api', significance: 'major' }
 
-    StageBlobs.stage(signed_ids, model.externalIdentifier) do
-      version_or_accession(object_client, model, existing, versioning_params)
-    end
+    StageBlobs.stage(signed_ids, model.externalIdentifier)
+    StageGlobus.stage(globus_ids, model.externalIdentifier)
 
-    StageGlobus.stage(globus_ids, model.externalIdentifier) do
-      version_or_accession(object_client, model, existing, versioning_params)
-    end
+    version_or_accession(object_client, model, existing, versioning_params)
 
     background_job_result.complete!
   rescue Dor::Services::Client::BadRequestError => e

--- a/app/services/stage_blobs.rb
+++ b/app/services/stage_blobs.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
 # Moves files from the ActiveStorage to the staging mount
+# @param [Hash] signed_ids a mapping of filenames to ActiveStorage signed id
+# @param [String] druid
+# @return [Integer] the number of files staged
 class StageBlobs
   def self.stage(signed_ids, druid)
     # Skip side effects if no signed IDs provided
-    return yield if signed_ids.empty?
+    return 0 if signed_ids.empty?
 
     blobs = Blobs.blobs_for(signed_ids)
     copy_files_to_staging(druid, blobs)
-    yield
     delete_from_active_storage(blobs.values)
+
+    blobs.size
   end
 
   # Copy files to the staging directory from ActiveStorage for the assembly workflow

--- a/app/services/stage_globus.rb
+++ b/app/services/stage_globus.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 # Moves files from the ActiveStorage to the staging mount
+# @param [Hash] globus_ids a mapping of filenames to their location on disk
+# @param [String] druid
+# @return [Integer] the number of files staged
 class StageGlobus
   def self.stage(globus_ids, druid)
-    # Skip side effects if no signed IDs provided
-    return yield if globus_ids.blank?
+    return 0 if globus_ids.blank?
 
     dir = StagingDirectory.new(druid: druid, staging_location: Settings.staging_location)
     globus_ids.select { |_key, value| value&.match?(%r{^globus://}) }.each do |filename, globus_path|
       dir.copy_file(globus_path.gsub('globus://', Settings.globus_location), filename)
-    end
-    yield
+    end.size
   end
 end

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -89,11 +89,11 @@ RSpec.describe IngestJob do
       it 'ingests an object' do
         expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
         expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'registrationWF')
-        expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').twice
+        expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').once
         expect(workflow_client).to have_received(:create_workflow_by_name)
           .with(druid, 'registrationWF', version: 1, lane_id: 'default')
         expect(workflow_client).to have_received(:create_workflow_by_name)
-          .with(druid, 'accessionWF', version: 1, lane_id: 'default').twice
+          .with(druid, 'accessionWF', version: 1, lane_id: 'default').once
         expect(actual_result).to be_complete
         expect(actual_result.output).to match({ druid: druid })
         expect(ActiveStorage::PurgeJob).to have_received(:perform_later).with(blob)
@@ -106,11 +106,11 @@ RSpec.describe IngestJob do
       it 'ingests an object' do
         expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
         expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'registrationWF')
-        expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').twice
+        expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').once
         expect(workflow_client).to have_received(:create_workflow_by_name)
           .with(druid, 'registrationWF', version: 1, lane_id: 'low')
         expect(workflow_client).to have_received(:create_workflow_by_name)
-          .with(druid, 'accessionWF', version: 1, lane_id: 'low').twice
+          .with(druid, 'accessionWF', version: 1, lane_id: 'low').once
         expect(actual_result).to be_complete
         expect(actual_result.output).to match({ druid: druid })
         expect(ActiveStorage::PurgeJob).to have_received(:perform_later).with(blob)
@@ -135,11 +135,11 @@ RSpec.describe IngestJob do
     it 'ingests an object' do
       expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
       expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'registrationWF')
-      expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').twice
+      expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').once
       expect(workflow_client).to have_received(:create_workflow_by_name)
         .with(druid, 'registrationWF', version: 1, lane_id: 'default')
       expect(workflow_client).to have_received(:create_workflow_by_name)
-        .with(druid, 'accessionWF', version: 1, lane_id: 'default').twice
+        .with(druid, 'accessionWF', version: 1, lane_id: 'default').once
       expect(actual_result).to be_complete
       expect(actual_result.output).to match({ druid: druid })
     end
@@ -202,11 +202,11 @@ RSpec.describe IngestJob do
                                   signed_ids: signed_ids)
       expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
       expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'registrationWF')
-      expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').twice
+      expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').once
       expect(workflow_client).to have_received(:create_workflow_by_name)
         .with(druid, 'registrationWF', version: 1, lane_id: 'default')
       expect(workflow_client).to have_received(:create_workflow_by_name)
-        .with(druid, 'accessionWF', version: 1, lane_id: 'default').twice
+        .with(druid, 'accessionWF', version: 1, lane_id: 'default').once
       expect(actual_result).to be_complete
       expect(actual_result.output).to match({ druid: druid })
       expect(ActiveStorage::PurgeJob).to have_received(:perform_later).with(blob)
@@ -226,7 +226,7 @@ RSpec.describe IngestJob do
                                   signed_ids: signed_ids)
       expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
       expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'registrationWF')
-      expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').twice
+      expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'accessionWF').once
       expect(workflow_client).not_to have_received(:create_workflow_by_name)
         .with(druid, 'registrationWF', version: 1, lane_id: 'low')
       expect(workflow_client).not_to have_received(:create_workflow_by_name)

--- a/spec/jobs/update_job_spec.rb
+++ b/spec/jobs/update_job_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe UpdateJob do
       expect(version_client).not_to have_received(:open)
       expect(version_client).not_to have_received(:close)
       expect(accession_client).to have_received(:start)
-        .with(description: 'Updated metadata', significance: 'major', workflow: 'accessionWF').twice
+        .with(description: 'Updated metadata', significance: 'major', workflow: 'accessionWF').once
     end
 
     it 'opens and closes the version without kicking off accessioning if start_workflow is false' do
@@ -109,9 +109,9 @@ RSpec.describe UpdateJob do
                                   background_job_result: result,
                                   signed_ids: signed_ids,
                                   start_workflow: false)
-      expect(version_client).to have_received(:open).twice
+      expect(version_client).to have_received(:open).once
       expect(version_client).to have_received(:close)
-        .with(description: 'Update via sdr-api', significance: 'major', start_accession: false).twice
+        .with(description: 'Update via sdr-api', significance: 'major', start_accession: false).once
       expect(accession_client).not_to have_received(:start)
     end
   end
@@ -224,7 +224,7 @@ RSpec.describe UpdateJob do
       expect(version_client).not_to have_received(:open)
       expect(version_client).not_to have_received(:close)
       expect(accession_client).to have_received(:start)
-        .with(description: 'Update via sdr-api', significance: 'major', workflow: 'accessionWF').twice
+        .with(description: 'Update via sdr-api', significance: 'major', workflow: 'accessionWF').once
     end
 
     it 'does not kick off accessioning if start_workflow is false' do

--- a/spec/services/stage_blobs_spec.rb
+++ b/spec/services/stage_blobs_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe StageBlobs do
     end
 
     context 'when signed IDs are supplied' do
-      it 'copies files to staging, yields, and cleans up active-storage' do
-        expect { |b| described_class.stage(signed_ids, druid, &b) }.to yield_control.once
+      it 'copies files to staging, and cleans up active-storage and returns 1' do
+        expect(described_class.stage(signed_ids, druid)).to be 1
         expect(described_class).to have_received(:copy_files_to_staging).once
         expect(described_class).to have_received(:delete_from_active_storage).once
       end
@@ -29,8 +29,8 @@ RSpec.describe StageBlobs do
     context 'when signed IDs are not supplied' do
       let(:signed_ids) { [] }
 
-      it 'yields and does nothing else' do
-        expect { |b| described_class.stage(signed_ids, druid, &b) }.to yield_control.once
+      it 'does nothing and returns 0' do
+        expect(described_class.stage(signed_ids, druid)).to be 0 
         expect(described_class).not_to have_received(:copy_files_to_staging)
         expect(described_class).not_to have_received(:delete_from_active_storage)
       end

--- a/spec/services/stage_blobs_spec.rb
+++ b/spec/services/stage_blobs_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe StageBlobs do
       let(:signed_ids) { [] }
 
       it 'does nothing and returns 0' do
-        expect(described_class.stage(signed_ids, druid)).to be 0 
+        expect(described_class.stage(signed_ids, druid)).to be 0
         expect(described_class).not_to have_received(:copy_files_to_staging)
         expect(described_class).not_to have_received(:delete_from_active_storage)
       end

--- a/spec/services/stage_globus_spec.rb
+++ b/spec/services/stage_globus_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe StageGlobus do
     end
 
     context 'when globus IDs are supplied' do
-      it 'copies files to staging, yields, and cleans up active-storage' do
-        expect { |b| described_class.stage(globus_ids, druid, &b) }.to yield_control.once
+      it 'copies files to staging and cleans up active-storage and returns 1' do
+        expect(described_class.stage(globus_ids, druid)).to be 1
         expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
       end
     end
@@ -31,8 +31,8 @@ RSpec.describe StageGlobus do
     context 'when signed IDs are not supplied' do
       let(:globus_ids) { [] }
 
-      it 'yields and does nothing else' do
-        expect { |b| described_class.stage(globus_ids, druid, &b) }.to yield_control.once
+      it 'does nothing and returns 0' do
+        expect(described_class.stage(globus_ids, druid)).to be 0
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

We had a situation where large file deposits were triggering a race
condition where multiple accession workflows resulted in techmd getting
confused about missing files.

See https://github.com/sul-dlss/happy-heron/issues/3007

This change ensures that only one AccessionWF is started when staging
from ActiveStorage or Globus. The code assumes that a deposit
stages from ActiveStorage or Globus, but not both.

## How was this change tested? 🤨

Integration tests in stage.

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



