### PR TITLE
update cocina-models gem to 0.90.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'action_policy'
 gem 'amazing_print'
-gem 'cocina-models', '~> 0.89.0'
+gem 'cocina-models', '~> 0.90.0'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.89.1)
+    cocina-models (0.90.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -142,9 +142,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (12.13.1)
+    dor-services-client (12.14.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.89.0)
+      cocina-models (~> 0.90.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -407,7 +407,7 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.89.0)
+  cocina-models (~> 0.90.0)
   committee
   config (~> 2.0)
   dlss-capistrano
@@ -436,4 +436,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.4.6
+   2.4.10


### PR DESCRIPTION
## Why was this change made? 🤔

This should have been in my previous PR updating the openapi.yml to match the cocina-models change.  D'oh.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



