### PR TITLE
Test invalid JSON file upload

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module SdrApi
     config.load_defaults 7.0
 
     # accept_request_filter omits OKComputer and Sidekiq
-    accept_proc = proc { |request| request.path.start_with?('/v1') }
+    accept_proc = proc { |request| request.path.start_with?('/v1') && !request.path.start_with?('/v1/disk/') }
     config.middleware.use(
       Committee::Middleware::RequestValidation,
       schema_path: 'openapi.yml',

--- a/spec/requests/direct_uploads_spec.rb
+++ b/spec/requests/direct_uploads_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Direct upload' do
-  let(:json) do
-    '{"blob":{"filename":"Gemfile.lock","byte_size":1751,"checksum":"vQ0xN+GwJBg9iEAcD4v73g==",' \
-      '"content_type":"text/html"}}'
-  end
+  let(:filename) { 'test.txt' }
+  let(:data) { 'text' }
+  let(:checksum) { OpenSSL::Digest::MD5.base64digest(data) }
+  let(:byte_size) { data.length }
+  let(:content_type) { 'text/plain' }
+  let(:json) { JSON.dump({ blob: { filename:, byte_size:, checksum:, content_type: } }) }
 
   context 'when unauthorized' do
     it 'returns 401' do
@@ -23,6 +25,56 @@ RSpec.describe 'Direct upload' do
            params: json,
            headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
+    end
+  end
+
+  context 'when uploading a file' do
+    it 'returns 204' do
+      post '/v1/direct_uploads',
+           params: json,
+           headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to be_successful
+      expect(response.media_type).to eq 'application/json'
+      direct_upload = response.parsed_body
+
+      signed_id = direct_upload['signed_id']
+      expect(signed_id).to be_truthy
+
+      direct_upload_uri = URI.parse(direct_upload['direct_upload']['url'])
+      expect(direct_upload_uri.path).to start_with('/v1/disk/')
+
+      put direct_upload_uri.path,
+          params: data,
+          headers: { 'Content-Type' => content_type, 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to have_http_status(:no_content) # Status: 204
+    end
+  end
+
+  context 'when uploading a invalid json file with application/json' do
+    let(:content_type) { 'application/json' }
+
+    it 'returns 204' do
+      post '/v1/direct_uploads',
+           params: json,
+           headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to be_successful
+      expect(response.media_type).to eq 'application/json'
+      direct_upload = response.parsed_body
+
+      signed_id = direct_upload['signed_id']
+      expect(signed_id).to be_truthy
+
+      direct_upload_uri = URI.parse(direct_upload['direct_upload']['url'])
+      expect(direct_upload_uri.path).to start_with('/v1/disk/')
+
+      put direct_upload_uri.path,
+          params: data,
+          headers: { 'Content-Type' => content_type, 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to have_http_status(:no_content) # Status: 204
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Testing that application/json can be uploaded with `application/json` even when it doesn't contain valid JSON.

Refs https://github.com/sul-dlss/happy-heron/issues/3075

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



