### PR TITLE
Normalize logging

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -102,6 +102,7 @@ class ResourcesController < ApplicationController
 
   def cocina_update_model
     new_model_params = cocina_update_params.deep_dup
+    Rails.logger.info("updating cocina: #{JSON.generate(new_model_params)}")
     decorate_file_sets(new_model_params)
     Cocina::Models.build(new_model_params)
   end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -2,4 +2,5 @@
 
 Rails.application.configure do
   config.lograge.enabled = Rails.env.production?
+  config.lograge.base_controller_class = 'ActionController::API'
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Get app log messages going to `production.log` again, without chattiness of logging every http request since sdr-api is on the www.

Fixes #178

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



