### PR TITLE
Excise references to Symphony

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-Honeybadger.configure do |config|
-  config.before_notify do |notice|
-    # Symphony is unavailable
-    notice.halt! if notice.error_message =~ /unableToAcquireSession/
-  end
-end

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe IngestJob do
         .to receive(:register)
         .and_raise(Dor::Services::Client::BadRequestError.new(response: '',
                                                               errors: [
-                                                                { 'title' => 'Catkey not in Symphony blah blah' }
+                                                                { 'title' => 'Record not in catalog blah blah' }
                                                               ]))
     end
 
@@ -260,7 +260,7 @@ RSpec.describe IngestJob do
       expect(actual_result).to be_complete
       expect(actual_result.output)
         .to match({ errors: [title: 'HTTP 400 (Bad Request) from dor-services-app',
-                             message: 'Catkey not in Symphony blah blah ()'] })
+                             message: 'Record not in catalog blah blah ()'] })
       expect(ActiveStorage::PurgeJob).not_to have_received(:perform_later).with(blob)
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

This commit removes references to Symphony now that the migration to Folio is imminent.

# How was this change tested? 🤨

N/A
