### PR TITLE
Relax validation of cocina version.

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -92,7 +92,7 @@ class ResourcesController < ApplicationController
 
   def validate_version
     request_version = request.headers['X-Cocina-Models-Version']
-    return if !request_version || request_version == Cocina::Models::VERSION
+    return if !request_version || CocinaVersionValidator.valid?(request_version)
 
     error = StandardError.new("The API accepts cocina-models version #{Cocina::Models::VERSION} " \
                               "but you provided #{request_version}.  " \

--- a/app/services/cocina_version_validator.rb
+++ b/app/services/cocina_version_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Checks that the major and minor cocina versions match.
+class CocinaVersionValidator
+  # @param [String] check_cocina_version, e.g., 1.1.2
+  # @return [Boolean] true if major and minor versions match current cocina version
+  def self.valid?(check_cocina_version, cocina_version: Cocina::Models::VERSION)
+    check_cocina_version.split('.')[0..1] == cocina_version.split('.')[0..1]
+  end
+end

--- a/spec/services/cocina_version_validator_spec.rb
+++ b/spec/services/cocina_version_validator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CocinaVersionValidator do
+  context 'when identical versions' do
+    it 'returns true' do
+      expect(described_class.valid?(Cocina::Models::VERSION)).to be true
+      expect(described_class.valid?('1.1.1', cocina_version: '1.1.1')).to be true
+    end
+  end
+
+  context 'when identical major and minor versions' do
+    it 'returns true' do
+      expect(described_class.valid?('1.1.1', cocina_version: '1.1.2')).to be true
+    end
+  end
+
+  context 'when different major versions' do
+    it 'returns false' do
+      expect(described_class.valid?('1.1.1', cocina_version: '2.1.1')).to be false
+    end
+  end
+
+  context 'when different minor versions' do
+    it 'returns false' do
+      expect(described_class.valid?('1.1.1', cocina_version: '1.2.1')).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
So that minor cocina gem changes can be rolled out without have to update everywhere.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

