### PR TITLE
bump cocina-models and dor-services-client versions to get new field for file types, update openapi.yml accordingly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'action_policy'
 gem 'amazing_print'
 gem 'bcrypt', '~> 3.1.7' # Use Active Model has_secure_password
 gem 'bootsnap', '>= 1.4.2', require: false # Reduces boot times through caching; required in config/boot.rb
-gem 'cocina-models', '~> 0.91.0'
+gem 'cocina-models', '~> 0.92.0'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,13 +104,14 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.91.4)
+    cocina-models (0.92.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       edtf
       equivalent-xml
+      i18n
       jsonpath
       nokogiri
       openapi3_parser
@@ -143,9 +144,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (13.1.1)
+    dor-services-client (13.2.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.91.0)
+      cocina-models (~> 0.92.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -417,7 +418,7 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.91.0)
+  cocina-models (~> 0.92.0)
   committee
   config (~> 2.0)
   dlss-capistrano

--- a/openapi.yml
+++ b/openapi.yml
@@ -1168,6 +1168,9 @@ components:
         hasMimeType:
           description: MIME Type of the File.
           type: string
+        languageTag:
+          description: "BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang"
+          type: string
         use:
           description: Use for the File.
           type: string
@@ -1879,6 +1882,8 @@ components:
         version:
           type: integer
         hasMimeType:
+          type: string
+        languageTag:
           type: string
         externalIdentifier:
           type: string


### PR DESCRIPTION
## Why was this change made? 🤔

connects to sul-dlss/cocina-models#637 and sul-dlss/cocina-models#640

## How was this change tested? 🤨

unit tests

will run integration tests on QA or stage once all the SDR apps have been updated (i.e. DSA updated to latest cocina-models in [related PR](https://github.com/sul-dlss/dor-services-app/pull/4638), sdr-api updated to latest cocina-models in this PR, and access-update-scripts `cocina_level2_prs.rb` has been run)

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



