### PR TITLE
bump cocina-models and dor-servics-client versions to get updated validations, update openapi.yml accordingly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'action_policy'
 gem 'amazing_print'
 gem 'bcrypt', '~> 3.1.7' # Use Active Model has_secure_password
 gem 'bootsnap', '>= 1.4.2', require: false # Reduces boot times through caching; required in config/boot.rb
-gem 'cocina-models', '~> 0.92.0'
+gem 'cocina-models', '~> 0.93.0'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     amazing_print (1.5.0)
     ast (2.4.2)
     attr_extras (7.1.0)
-    base64 (0.1.1)
+    base64 (0.2.0)
     bcrypt (3.1.19)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
@@ -104,7 +104,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.92.0)
+    cocina-models (0.93.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -144,9 +144,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (13.2.0)
+    dor-services-client (13.3.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.92.0)
+      cocina-models (~> 0.93.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -418,7 +418,7 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.92.0)
+  cocina-models (~> 0.93.0)
   committee
   config (~> 2.0)
   dlss-capistrano

--- a/openapi.yml
+++ b/openapi.yml
@@ -1169,11 +1169,9 @@ components:
           description: MIME Type of the File.
           type: string
         languageTag:
-          description: "BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang"
-          type: string
+          $ref: '#/components/schemas/LanguageTag'
         use:
-          description: Use for the File.
-          type: string
+          $ref: '#/components/schemas/FileUse'
         hasMessageDigests:
           type: array
           items:
@@ -1268,6 +1266,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/File'
+    FileUse:
+      description: Use for the File.
+      type: string
+      nullable: true
     FolioCatalogLink:
       description: A linkage between an object and a Folio catalog record
       type: object
@@ -1396,6 +1398,10 @@ components:
         valueLanguage:
           # description: present for mapping to additional schemas in the future and for consistency but not otherwise used
           $ref: "#/components/schemas/DescriptiveValueLanguage"
+    LanguageTag:
+      description: "BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang"
+      type: string
+      nullable: true
     License:
       description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
       type: string
@@ -1884,11 +1890,11 @@ components:
         hasMimeType:
           type: string
         languageTag:
-          type: string
+          $ref: '#/components/schemas/LanguageTag'
         externalIdentifier:
           type: string
         use:
-          type: string
+          $ref: '#/components/schemas/FileUse'
         hasMessageDigests:
           type: array
           items:


### PR DESCRIPTION
## Why was this change made? 🤔

better validation for langauge tags, nilable language tags and use fields, stricter description validation

https://github.com/sul-dlss/cocina-models/releases/tag/v0.93.0

## How was this change tested? 🤨

unit tests

will run integration tests on QA or stage once all the SDR apps have been updated (i.e. DSA updated to latest cocina-models in [related PR](https://github.com/sul-dlss/dor-services-app/pull/4644), sdr-api updated to latest cocina-models in this PR, and access-update-scripts `cocina_level2_prs.rb` has been run)

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



