### PR TITLE
require ReleaseTag "what" attribute as part of cocina-models and dor-services-client upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ gem 'action_policy'
 gem 'amazing_print'
 gem 'bcrypt', '~> 3.1.7' # Use Active Model has_secure_password
 gem 'bootsnap', '>= 1.4.2', require: false # Reduces boot times through caching; required in config/boot.rb
-gem 'cocina-models', '~> 0.95.0'
+gem 'cocina-models', '~> 0.96.0'
 gem 'committee'
 gem 'config', '~> 2.0'
-gem 'dor-services-client', '~> 14.2'
+gem 'dor-services-client', '~> 14.5'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'druid-tools'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.95.1)
+    cocina-models (0.96.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -146,9 +146,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (14.2.1)
+    dor-services-client (14.5.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.95.1)
+      cocina-models (~> 0.96.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -429,11 +429,11 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.95.0)
+  cocina-models (~> 0.96.0)
   committee
   config (~> 2.0)
   dlss-capistrano
-  dor-services-client (~> 14.2)
+  dor-services-client (~> 14.5)
   dor-workflow-client (~> 7.0)
   druid-tools
   equivalent-xml

--- a/openapi.yml
+++ b/openapi.yml
@@ -1630,6 +1630,7 @@ components:
       additionalProperties: true
       required:
         - release
+        - what
       properties:
         who:
           description: Who did this release


### PR DESCRIPTION
## Why was this change made? 🤔

goes with https://github.com/sul-dlss/cocina-models/pull/697


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



