### PR TITLE
Change versioning in UpdateJob.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'bootsnap', '>= 1.4.2', require: false # Reduces boot times through caching;
 gem 'cocina-models', '~> 0.96.0'
 gem 'committee'
 gem 'config', '~> 2.0'
-gem 'dor-services-client', '~> 14.5'
+gem 'dor-services-client', '~> 14.6'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'druid-tools'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (14.5.0)
+    dor-services-client (14.6.1)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.96.0)
       deprecation
@@ -436,7 +436,7 @@ DEPENDENCIES
   committee
   config (~> 2.0)
   dlss-capistrano
-  dor-services-client (~> 14.5)
+  dor-services-client (~> 14.6)
   dor-workflow-client (~> 7.0)
   druid-tools
   equivalent-xml


### PR DESCRIPTION
closes #661

## Why was this change made? 🤔
So that UpdateJob is using the latest approach to opening / closing versions.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, integration tests

