### PR TITLE
Proxies user_versions param from ingest and update to version close.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,8 @@ GEM
       net-protocol
     net-ssh (7.2.3)
     nio4r (2.7.3)
+    nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
@@ -423,6 +425,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -42,7 +42,8 @@ class ResourcesController < ApplicationController
                             background_job_result: result,
                             start_workflow: params.fetch(:accession, false),
                             assign_doi: params.fetch(:assign_doi, false),
-                            priority: params.fetch(:priority, 'default'))
+                            priority: params.fetch(:priority, 'default'),
+                            user_versions: params.fetch(:user_versions, 'none'))
 
     render json: { jobId: result.id },
            location: result,
@@ -69,6 +70,7 @@ class ResourcesController < ApplicationController
                             signed_ids:,
                             globus_ids:,
                             version_description: params[:versionDescription],
+                            user_versions: params.fetch(:user_versions, 'none'),
                             background_job_result: result)
 
     render json: { jobId: result.id },
@@ -79,7 +81,7 @@ class ResourcesController < ApplicationController
 
   private
 
-  CREATE_PARAMS_EXCLUDE_FROM_COCINA = %i[action controller resource accession priority assign_doi].freeze
+  CREATE_PARAMS_EXCLUDE_FROM_COCINA = %i[action controller resource accession priority assign_doi user_versions].freeze
   ID_NAMESPACE = 'https://cocina.sul.stanford.edu'
 
   def cocina_create_params
@@ -87,7 +89,7 @@ class ResourcesController < ApplicationController
   end
 
   def cocina_update_params
-    params.except(:action, :controller, :resource, :id, :versionDescription).to_unsafe_h
+    params.except(:action, :controller, :resource, :id, :versionDescription, :user_versions).to_unsafe_h
   end
 
   def validate_version

--- a/openapi.yml
+++ b/openapi.yml
@@ -126,6 +126,15 @@ paths:
           name: assign_doi
           schema:
             type: boolean
+        - in: query
+          name: user_versions
+          description: Create, update, or do nothing with user versions on close
+          schema:
+            type: string
+            enum:
+              - "none"
+              - "new"
+              - "update"
       requestBody:
         description: The metadata for the object
         required: true
@@ -208,6 +217,15 @@ paths:
           in: query
           schema:
             type: string
+        - name: user_versions
+          in: query
+          description: Create, update, or do nothing with user versions on close
+          schema:
+            type: string
+            enum:
+              - "none"
+              - "new"
+              - "update"
       requestBody:
         description: The metadata for the object
         required: true

--- a/spec/jobs/update_job_spec.rb
+++ b/spec/jobs/update_job_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe UpdateJob do
                                     signed_ids:)
         expect(version_client).to have_received(:open).with(description: 'Update via sdr-api').once
         expect(object_client).to have_received(:update).with(params: model, skip_lock: true)
-        expect(version_client).to have_received(:close)
+        expect(version_client).to have_received(:close).with(user_versions: 'none')
         expect(actual_result).to be_complete
         expect(actual_result.output).to match({ druid: })
         expect(ActiveStorage::PurgeJob).to have_received(:perform_later).with(blob)
@@ -103,6 +103,17 @@ RSpec.describe UpdateJob do
                                  detail: 'Attempted to open version 2 but it cannot be opened.' }] })
         expect(version_client).not_to have_received(:open)
       end
+    end
+  end
+
+  context 'when user_version provided' do
+    it 'calls version close with user_version' do
+      described_class.perform_now(model_params: model.to_h,
+                                  background_job_result: result,
+                                  signed_ids:,
+                                  user_versions: 'new')
+      expect(version_client).to have_received(:close).with(user_versions: 'new')
+      expect(actual_result).to be_complete
     end
   end
 

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe 'Create a collection' do
                                                               globus_ids: {},
                                                               start_workflow: false,
                                                               assign_doi: false,
-                                                              priority: 'default')
+                                                              priority: 'default',
+                                                              user_versions: 'none')
     end
   end
 

--- a/spec/requests/create_dro_spec.rb
+++ b/spec/requests/create_dro_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Create a DRO' do
     model_params.with_indifferent_access
   end
 
-  context 'when priority is not provided' do
+  context 'when priority or user versions is not provided' do
     it 'registers the resource and kicks off IngestJob' do
       post '/v1/resources',
            params: request,
@@ -74,7 +74,27 @@ RSpec.describe 'Create a DRO' do
                                                               globus_ids: {},
                                                               start_workflow: false,
                                                               assign_doi: false,
-                                                              priority: 'default')
+                                                              priority: 'default',
+                                                              user_versions: 'none')
+    end
+  end
+
+  context 'when user versions is provided' do
+    it 'registers the resource and kicks off IngestJob' do
+      post '/v1/resources?user_versions=new',
+           params: request,
+           headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_created
+      expect(response.location).to be_present
+      expect(response.parsed_body['jobId']).to be_present
+      expect(IngestJob).to have_received(:perform_later).with(model_params: expected_model_params,
+                                                              background_job_result: instance_of(BackgroundJobResult),
+                                                              signed_ids: { 'file2.txt' => signed_id },
+                                                              globus_ids: {},
+                                                              start_workflow: false,
+                                                              assign_doi: false,
+                                                              priority: 'default',
+                                                              user_versions: 'new')
     end
   end
 
@@ -104,7 +124,8 @@ RSpec.describe 'Create a DRO' do
                                                               globus_ids: {},
                                                               start_workflow: true,
                                                               assign_doi: false,
-                                                              priority: 'low')
+                                                              priority: 'low',
+                                                              user_versions: 'none')
     end
   end
 
@@ -119,7 +140,8 @@ RSpec.describe 'Create a DRO' do
                                                               globus_ids: {},
                                                               start_workflow: true,
                                                               assign_doi: false,
-                                                              priority: 'default')
+                                                              priority: 'default',
+                                                              user_versions: 'none')
     end
   end
 
@@ -134,7 +156,8 @@ RSpec.describe 'Create a DRO' do
                                                               globus_ids: {},
                                                               start_workflow: false,
                                                               assign_doi: false,
-                                                              priority: 'default')
+                                                              priority: 'default',
+                                                              user_versions: 'none')
     end
   end
 
@@ -149,7 +172,8 @@ RSpec.describe 'Create a DRO' do
                                                               globus_ids: {},
                                                               start_workflow: false,
                                                               assign_doi: true,
-                                                              priority: 'default')
+                                                              priority: 'default',
+                                                              user_versions: 'none')
     end
   end
 
@@ -196,7 +220,8 @@ RSpec.describe 'Create a DRO' do
                                                               globus_ids:,
                                                               start_workflow: false,
                                                               assign_doi: false,
-                                                              priority: 'default')
+                                                              priority: 'default',
+                                                              user_versions: 'none')
     end
   end
 
@@ -235,7 +260,8 @@ RSpec.describe 'Create a DRO' do
                                                               globus_ids: {},
                                                               start_workflow: false,
                                                               assign_doi: false,
-                                                              priority: 'default')
+                                                              priority: 'default',
+                                                              user_versions: 'none')
     end
   end
 
@@ -258,7 +284,8 @@ RSpec.describe 'Create a DRO' do
                                                               globus_ids: {},
                                                               start_workflow: false,
                                                               assign_doi: false,
-                                                              priority: 'default')
+                                                              priority: 'default',
+                                                              user_versions: 'none')
     end
   end
 

--- a/spec/requests/update_resource_spec.rb
+++ b/spec/requests/update_resource_spec.rb
@@ -80,7 +80,26 @@ RSpec.describe 'Update a resource' do
                                                             background_job_result: instance_of(BackgroundJobResult),
                                                             signed_ids: { 'file2.txt' => file_id },
                                                             globus_ids: {},
-                                                            version_description:)
+                                                            version_description:,
+                                                            user_versions: 'none')
+  end
+
+  context 'when user_versions is provided' do
+    it 'registers the resource and kicks off UpdateJob' do
+      put "/v1/resources/druid:bc999dg9999?versionDescription=#{version_description}&user_versions=new",
+          params: request,
+          headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to be_accepted
+      expect(response.location).to be_present
+      expect(response.parsed_body['jobId']).to be_present
+      expect(UpdateJob).to have_received(:perform_later).with(model_params: expected_model_params_without_file_ids,
+                                                              background_job_result: instance_of(BackgroundJobResult),
+                                                              signed_ids: { 'file2.txt' => file_id },
+                                                              globus_ids: {},
+                                                              version_description:,
+                                                              user_versions: 'new')
+    end
   end
 
   context 'when wrong version of cocina models is supplied' do
@@ -129,7 +148,8 @@ RSpec.describe 'Update a resource' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: {},
                                                               globus_ids: {},
-                                                              version_description: nil)
+                                                              version_description: nil,
+                                                              user_versions: 'none')
     end
   end
 
@@ -147,7 +167,8 @@ RSpec.describe 'Update a resource' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: {},
                                                               globus_ids: {},
-                                                              version_description: nil)
+                                                              version_description: nil,
+                                                              user_versions: 'none')
     end
   end
 
@@ -175,7 +196,8 @@ RSpec.describe 'Update a resource' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => file_id },
                                                               globus_ids: {},
-                                                              version_description: nil)
+                                                              version_description: nil,
+                                                              user_versions: 'none')
     end
   end
 


### PR DESCRIPTION
closes #673

## Why was this change made? 🤔
To allow H2 to pass on user versioning requests to DSA.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit


