### PR TITLE
Add mutex_m to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'jbuilder', '~> 2.7' # Build JSON APIs with ease. Read more: https://github.
 gem 'jwt' # JSON web tokens (for authentication)
 gem 'lograge'
 gem 'marcel'
+gem 'mutex_m'
 gem 'okcomputer'
 gem 'pg' # Postgres database client
 gem 'rails', '~> 7.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ GEM
     minitest (5.24.0)
     msgpack (1.7.2)
     multi_json (1.15.0)
+    mutex_m (0.2.0)
     net-http (0.4.1)
       uri
     net-imap (0.4.14)
@@ -453,6 +454,7 @@ DEPENDENCIES
   jwt
   lograge
   marcel
+  mutex_m
   okcomputer
   pg
   puma (~> 5.6)


### PR DESCRIPTION
## Why was this change made? 🤔

Addresses this warning output from the cron:

```
/opt/app/sdr/sdr-api/shared/bundle/ruby/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: /usr/local/rvm/rubies/ruby-3.3.1/lib/ruby/3.3.0/mutex_m.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of activesupport-7.0.8.4 to add mutex_m into its gemspec.
I, [2024-06-26T00:00:05.486957 #2569575]  INFO -- : Queued 0 uploads for purging.
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



