### PR TITLE
Add comment about `mutex_m` dependency in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'jbuilder', '~> 2.7' # Build JSON APIs with ease. Read more: https://github.
 gem 'jwt' # JSON web tokens (for authentication)
 gem 'lograge'
 gem 'marcel'
-gem 'mutex_m'
+gem 'mutex_m' # This can be removed when H2 is upgraded to Rails 7.1
 gem 'okcomputer'
 gem 'pg' # Postgres database client
 gem 'rails', '~> 7.0.3'


### PR DESCRIPTION
sdr-api does not depend upon `mutex_m` directly, but Rails does. Rails adds this dependency as of version 7.1.0, so we will no longer need this in the sdr-api `Gemfile`.
