### PR TITLE
Allows specifying whether to close version upon update.

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -40,7 +40,7 @@ class ResourcesController < ApplicationController
                             signed_ids:,
                             globus_ids:,
                             background_job_result: result,
-                            start_workflow: params.fetch(:accession, false),
+                            accession: params.fetch(:accession, false),
                             assign_doi: params.fetch(:assign_doi, false),
                             priority: params.fetch(:priority, 'default'),
                             user_versions: params.fetch(:user_versions, 'none'))
@@ -55,6 +55,7 @@ class ResourcesController < ApplicationController
   # PUT /resource/:id
   # This just proxies the response from DOR services app
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def update
     begin
       cocina_dro = cocina_update_model
@@ -71,13 +72,15 @@ class ResourcesController < ApplicationController
                             globus_ids:,
                             version_description: params[:versionDescription],
                             user_versions: params.fetch(:user_versions, 'none'),
-                            background_job_result: result)
+                            background_job_result: result,
+                            accession: params.fetch(:accession, false))
 
     render json: { jobId: result.id },
            location: result,
            status: :accepted
   end
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   private
 
@@ -89,7 +92,7 @@ class ResourcesController < ApplicationController
   end
 
   def cocina_update_params
-    params.except(:action, :controller, :resource, :id, :versionDescription, :user_versions).to_unsafe_h
+    params.except(:action, :controller, :resource, :id, :versionDescription, :user_versions, :accession).to_unsafe_h
   end
 
   def validate_version

--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -14,6 +14,7 @@ class UpdateJob < ApplicationJob
   # @param [Hash] filename, signed_ids for the blobs
   # @param [Hash] filename, globus_ids for the staged Globus files
   # @param [BackgroundJobResult] background_job_result
+  # @param [Boolean] accession if true, closes the current version
   # @param [String] version_description
   # @param [String] user_versions ('none') - create, update, or do nothing with user versions on close.
   # rubocop:disable Metrics/AbcSize
@@ -24,7 +25,8 @@ class UpdateJob < ApplicationJob
               signed_ids: {},
               globus_ids: {},
               version_description: nil,
-              user_versions: 'none')
+              user_versions: 'none',
+              accession: true)
     @background_job_result = background_job_result
     background_job_result_processing!
 
@@ -48,7 +50,7 @@ class UpdateJob < ApplicationJob
     StageBlobs.stage(signed_ids, model.externalIdentifier)
     StageGlobus.stage(globus_ids, model.externalIdentifier)
 
-    object_client.version.close(user_versions:)
+    object_client.version.close(user_versions:) if accession
 
     background_job_result.complete!
   rescue Dor::Services::Client::BadRequestError => e

--- a/openapi.yml
+++ b/openapi.yml
@@ -112,7 +112,7 @@ paths:
       parameters:
         - in: query
           name: accession
-          description: If set to true the accessioning workflow will be started
+          description: If set to true the version will be closed
           schema:
             type: boolean
         - in: query
@@ -213,6 +213,11 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: accession
+          in: query          
+          description: If set to true the version will be closed
+          schema:
+            type: boolean
         - name: versionDescription
           in: query
           schema:

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -158,9 +158,9 @@ RSpec.describe IngestJob do
   context 'when registering only' do
     let(:objects_client) { instance_double(Dor::Services::Client::Objects, register: response_dro) }
 
-    it 'ingests an object' do
+    it 'ingests an object without closing' do
       described_class.perform_now(model_params: model, background_job_result: result, signed_ids:,
-                                  start_workflow: false)
+                                  accession: false)
       expect(objects_client).to have_received(:register).with(params: Cocina::Models::RequestDRO.new(model),
                                                               assign_doi: false)
       expect(version_client).not_to have_received(:close)

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Create a collection' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: {},
                                                               globus_ids: {},
-                                                              start_workflow: false,
+                                                              accession: false,
                                                               assign_doi: false,
                                                               priority: 'default',
                                                               user_versions: 'none')

--- a/spec/requests/create_dro_spec.rb
+++ b/spec/requests/create_dro_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => signed_id },
                                                               globus_ids: {},
-                                                              start_workflow: false,
+                                                              accession: false,
                                                               assign_doi: false,
                                                               priority: 'default',
                                                               user_versions: 'none')
@@ -91,7 +91,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => signed_id },
                                                               globus_ids: {},
-                                                              start_workflow: false,
+                                                              accession: false,
                                                               assign_doi: false,
                                                               priority: 'default',
                                                               user_versions: 'new')
@@ -122,7 +122,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => signed_id },
                                                               globus_ids: {},
-                                                              start_workflow: true,
+                                                              accession: true,
                                                               assign_doi: false,
                                                               priority: 'low',
                                                               user_versions: 'none')
@@ -138,7 +138,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => signed_id },
                                                               globus_ids: {},
-                                                              start_workflow: true,
+                                                              accession: true,
                                                               assign_doi: false,
                                                               priority: 'default',
                                                               user_versions: 'none')
@@ -154,7 +154,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => signed_id },
                                                               globus_ids: {},
-                                                              start_workflow: false,
+                                                              accession: false,
                                                               assign_doi: false,
                                                               priority: 'default',
                                                               user_versions: 'none')
@@ -170,7 +170,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => signed_id },
                                                               globus_ids: {},
-                                                              start_workflow: false,
+                                                              accession: false,
                                                               assign_doi: true,
                                                               priority: 'default',
                                                               user_versions: 'none')
@@ -218,7 +218,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: {},
                                                               globus_ids:,
-                                                              start_workflow: false,
+                                                              accession: false,
                                                               assign_doi: false,
                                                               priority: 'default',
                                                               user_versions: 'none')
@@ -258,7 +258,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => signed_id },
                                                               globus_ids: {},
-                                                              start_workflow: false,
+                                                              accession: false,
                                                               assign_doi: false,
                                                               priority: 'default',
                                                               user_versions: 'none')
@@ -282,7 +282,7 @@ RSpec.describe 'Create a DRO' do
                                                               background_job_result: instance_of(BackgroundJobResult),
                                                               signed_ids: { 'file2.txt' => signed_id },
                                                               globus_ids: {},
-                                                              start_workflow: false,
+                                                              accession: false,
                                                               assign_doi: false,
                                                               priority: 'default',
                                                               user_versions: 'none')

--- a/spec/requests/update_resource_spec.rb
+++ b/spec/requests/update_resource_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Update a resource' do
   end
 
   it 'registers the resource and kicks off UpdateJob' do
-    put "/v1/resources/druid:bc999dg9999?versionDescription=#{version_description}",
+    put "/v1/resources/druid:bc999dg9999?accession=true&versionDescription=#{version_description}",
         params: request,
         headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
 
@@ -81,7 +81,8 @@ RSpec.describe 'Update a resource' do
                                                             signed_ids: { 'file2.txt' => file_id },
                                                             globus_ids: {},
                                                             version_description:,
-                                                            user_versions: 'none')
+                                                            user_versions: 'none',
+                                                            accession: true)
   end
 
   context 'when user_versions is provided' do
@@ -98,7 +99,8 @@ RSpec.describe 'Update a resource' do
                                                               signed_ids: { 'file2.txt' => file_id },
                                                               globus_ids: {},
                                                               version_description:,
-                                                              user_versions: 'new')
+                                                              user_versions: 'new',
+                                                              accession: false)
     end
   end
 
@@ -149,7 +151,8 @@ RSpec.describe 'Update a resource' do
                                                               signed_ids: {},
                                                               globus_ids: {},
                                                               version_description: nil,
-                                                              user_versions: 'none')
+                                                              user_versions: 'none',
+                                                              accession: false)
     end
   end
 
@@ -168,7 +171,8 @@ RSpec.describe 'Update a resource' do
                                                               signed_ids: {},
                                                               globus_ids: {},
                                                               version_description: nil,
-                                                              user_versions: 'none')
+                                                              user_versions: 'none',
+                                                              accession: false)
     end
   end
 
@@ -197,7 +201,8 @@ RSpec.describe 'Update a resource' do
                                                               signed_ids: { 'file2.txt' => file_id },
                                                               globus_ids: {},
                                                               version_description: nil,
-                                                              user_versions: 'none')
+                                                              user_versions: 'none',
+                                                              accession: false)
     end
   end
 


### PR DESCRIPTION
closes #710

## Why was this change made? 🤔
To allow an application to update a draft (without closing).


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



