### PR TITLE
Okcomputer check for workflow server

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -31,6 +31,18 @@ class TablesHaveDataCheck < OkComputer::Check
   end
 end
 
+# make sure we can hit the workflow service
+class WorkflowServerCheck < OkComputer::Check
+  def check
+    num_templates = Workflow.workflow_client.workflow_templates.size
+    mark_message "Workflow service has #{num_templates} templates."
+
+    mark_failure if num_templates.zero?
+  rescue StandardError => e
+    mark_failure
+  end
+end
+
 # confirm that the expected number of sidekiq worker processes and threads are running
 class SidekiqWorkerCountCheck < OkComputer::Check
   class ExpectedEnvVarMissing < StandardError; end
@@ -132,3 +144,4 @@ OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new
 OkComputer::Registry.register 'background_jobs', OkComputer::SidekiqLatencyCheck.new('default', 25)
 OkComputer::Registry.register 'feature-tables-have-data', TablesHaveDataCheck.new
 OkComputer::Registry.register 'sidekiq_worker_count', SidekiqWorkerCountCheck.new
+OkComputer::Registry.register 'workflow_server', WorkflowServerCheck.new

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -35,10 +35,11 @@ end
 class WorkflowServerCheck < OkComputer::Check
   def check
     num_templates = Workflow.workflow_client.workflow_templates.size
-    mark_message "Workflow service has #{num_templates} templates."
+    mark_message "#{Settings.workflow.url} has #{num_templates} templates."
 
     mark_failure if num_templates.zero?
   rescue StandardError => e
+    mark_message e.message
     mark_failure
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

We have outages today with sdr-api-prod being unable to connect to workflow-server-rails.  The errors that resulted from this were not obvious -- and I spent a couple hours chasing down dead ends before landing on this conclusion.  I realize we've talked in the past about not having okcomputer checks that test our own internal services, as nagios should already do this.  But in this case, nagios showed no problems, and an alert like this would save a lot of time to help quickly identify the problem.

![Screenshot 2024-10-21 at 3 02 31 PM](https://github.com/user-attachments/assets/530a2e68-fd4c-4a06-81a0-79f9a937d300)


## How was this change tested? 🤨

QA



