### PR TITLE
Remove reference to start_workflow param

### DIFF
--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe IngestJob do
   let(:version_client) do
     instance_double(Dor::Services::Client::ObjectVersion, close: true)
   end
-  let(:start_workflow) { true }
   let(:blob) { create(:singleton_blob_with_file) }
   let(:signed_ids) do
     { 'file2.txt' => ActiveStorage.verifier.generate(blob.id, purpose: :blob_id) }


### PR DESCRIPTION
## Why was this change made? 🤔
Removing leftover unused reference to `start_workflow` in spec


## How was this change tested? 🤨
Ran tests, no change


