### PR TITLE
Bump cocina-models to 0.99.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,9 +115,8 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.99.2)
+    cocina-models (0.99.3)
       activesupport
-      commonmarker (= 2.0.1)
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -126,7 +125,6 @@ GEM
       i18n
       jsonpath
       nokogiri
-      openapi3_parser
       openapi_parser (~> 1.0)
       super_diff
       thor
@@ -135,14 +133,11 @@ GEM
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (~> 1.0)
       rack (>= 1.5)
-    commonmarker (2.0.1-arm64-darwin)
-    commonmarker (2.0.1-x86_64-darwin)
-    commonmarker (2.0.1-x86_64-linux)
     concurrent-ruby (1.3.4)
     config (2.2.3)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    connection_pool (2.4.1)
+    connection_pool (2.5.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -198,12 +193,12 @@ GEM
       dry-logic (>= 1.4, < 2)
       dry-types (>= 1.7, < 2)
       zeitwerk (~> 2.6)
-    dry-struct (1.6.0)
-      dry-core (~> 1.0, < 2)
-      dry-types (>= 1.7, < 2)
+    dry-struct (1.7.0)
+      dry-core (~> 1.1)
+      dry-types (~> 1.8)
       ice_nine (~> 0.11)
       zeitwerk (~> 2.6)
-    dry-types (1.7.2)
+    dry-types (1.8.0)
       bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)
@@ -301,8 +296,6 @@ GEM
     nokogiri (1.18.1-x86_64-linux-gnu)
       racc (~> 1.4)
     okcomputer (1.18.5)
-    openapi3_parser (0.10.0)
-      commonmarker (>= 1.0)
     openapi_parser (1.0.0)
     optimist (3.2.0)
     ostruct (0.6.1)
@@ -435,7 +428,7 @@ GEM
       net-ssh (>= 2.8.0)
       ostruct
     stringio (3.1.2)
-    super_diff (0.14.0)
+    super_diff (0.15.0)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff


### PR DESCRIPTION
# Why was this change made?

To get commonmarker out of the dependencies, making the Ruby 3.4 upgrade process smoother.

# How was this change tested?

CI
