### PR TITLE
Set cron logging level to warn.

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -13,7 +13,7 @@
 require_relative 'environment'
 
 job_type :runner_hb,
-         "cd :path && bin/rails runner -e :environment ':task' " \
+         "cd :path && RAILS_LOG_LEVEL=warn bin/rails runner -e :environment ':task' " \
          "&& curl 'https://api.honeybadger.io/v1/check_in/:check_in' :output"
 
 every :day do


### PR DESCRIPTION


## Why was this change made? 🤔

So that we don't get unnecessary emails like this:
```
I, [2025-01-11T00:00:04.357414 #1507471]  INFO -- : Queued 0 uploads for purging.
```


