### PR TITLE
Normalize logging practices across services

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,11 +41,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new($stdout)
-                                       .tap  { |logger| logger.formatter = Logger::Formatter.new }
-                                       .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -2,4 +2,6 @@
 
 Rails.application.configure do
   config.lograge.enabled = Rails.env.production?
+  config.lograge.base_controller_class = ['ActionController::API', 'ActionController::Base']
+  config.lograge.ignore_actions = ['OkComputer::OkComputerController#show']
 end


### PR DESCRIPTION
# Why was this change made?

To normalize logging practices across services. To do this, lean on lograge and remove duplicate code added on upgrade to Rails 7.1.

Fixes #178 (when paired with sul-dlss/puppet#11735)

Closes #597 
