### PR TITLE
Bump cocina-models and dsc versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'action_policy'
 gem 'amazing_print'
 gem 'bcrypt', '~> 3.1.7' # Use Active Model has_secure_password
 gem 'bootsnap', '>= 1.4.2', require: false # Reduces boot times through caching; required in config/boot.rb
-gem 'cocina-models', '~> 0.101.0'
+gem 'cocina-models', '~> 0.101.1'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 15.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.101.0)
+    cocina-models (0.101.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -155,9 +155,9 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.1)
-    dor-services-client (15.6.0)
+    dor-services-client (15.6.1)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.101.0)
+      cocina-models (~> 0.101.1)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -485,7 +485,7 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.101.0)
+  cocina-models (~> 0.101.1)
   committee
   config (~> 2.0)
   dlss-capistrano


### PR DESCRIPTION
## Why was this change made? 🤔

To keep in sync with latest cocina-model patch release and clients.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



