### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
 server 'sdr-api-prod.stanford.edu', user: 'sdr', roles: %w[app db web]
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
 server 'sdr-api-qa.stanford.edu', user: 'sdr', roles: %w[app db web]
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
 server 'sdr-api-stage.stanford.edu', user: 'sdr', roles: %w[app db web]
-
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.