### PR TITLE
Bumping cocina-models version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'action_policy'
 gem 'amazing_print'
 gem 'bcrypt', '~> 3.1.7' # Use Active Model has_secure_password
 gem 'bootsnap', '>= 1.4.2', require: false # Reduces boot times through caching; required in config/boot.rb
-gem 'cocina-models', '~> 0.103.0'
+gem 'cocina-models', '~> 0.104.0'
 gem 'committee'
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 15.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.103.2)
+    cocina-models (0.104.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -155,9 +155,9 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.1)
-    dor-services-client (15.11.0)
+    dor-services-client (15.12.0)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.103.2)
+      cocina-models (~> 0.104.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -487,7 +487,7 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  cocina-models (~> 0.103.0)
+  cocina-models (~> 0.104.0)
   committee
   config (~> 2.0)
   dlss-capistrano

--- a/openapi.yml
+++ b/openapi.yml
@@ -1587,6 +1587,49 @@ components:
         type:
           description: The relationship of the related resource to the described resource.
           type: string
+        dataCiteRelationType:
+          description: The DataCite relationType describing the relationship from the related resource to the described resource.
+            See https://datacite-metadata-schema.readthedocs.io/en/4.6/appendices/appendix-1/relationType
+          type: string
+          enum:
+            - 'IsCitedBy'
+            - 'Cites'
+            - 'IsSupplementTo'
+            - 'IsSupplementedBy'
+            - 'IsContinuedBy'
+            - 'Continues'
+            - 'Describes'
+            - 'IsDescribedBy'
+            - 'HasMetadata'
+            - 'IsMetadataFor'
+            - 'HasVersion'
+            - 'IsVersionOf'
+            - 'IsNewVersionOf'
+            - 'IsPreviousVersionOf'
+            - 'IsPartOf'
+            - 'HasPart'
+            - 'IsPublishedIn'
+            - 'IsReferencedBy'
+            - 'References'
+            - 'IsDocumentedBy'
+            - 'Documents'
+            - 'IsCompiledBy'
+            - 'Compiles'
+            - 'IsVariantFormOf'
+            - 'IsOriginalFormOf'
+            - 'IsIdenticalTo'
+            - 'IsReviewedBy'
+            - 'Reviews'
+            - 'IsDerivedFrom'
+            - 'IsSourceOf'
+            - 'IsRequiredBy'
+            - 'Requires'
+            - 'Obsoletes'
+            - 'IsObsoletedBy'
+            - 'IsCollectedBy'
+            - 'Collects'
+            - 'IsTranslationOf'
+            - 'HasTranslation'
         status:
           description: Status of the related resource relative to other related resources.
           type: string


### PR DESCRIPTION
## Why was this change made? 🤔
To support cocina-models 0.104.0 with `dataCiteRelationType`.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



