### PR TITLE
Provide context as named param when HB notifying.

### DIFF
--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -66,7 +66,7 @@ class IngestJob < ApplicationJob
 
     # Otherwise return an error on background_job_result but exit cleanly.
     Honeybadger.notify('All retries failed',
-                       { external_identifier: druid })
+                       context: { external_identifier: druid })
     background_job_result.output = background_job_result.output.merge({ errors: [title: 'All retries failed',
                                                                                  message: e.message] })
     background_job_result.complete!

--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -121,9 +121,9 @@ class UpdateJob < ApplicationJob
 
   def background_job_complete_with_error!(error_title, error_detail, druid, existing_version, provided_version)
     Honeybadger.notify("#{error_title}: #{error_detail}",
-                       { external_identifier: druid,
-                         existing_version:,
-                         provided_version: })
+                       context: { external_identifier: druid,
+                                  existing_version:,
+                                  provided_version: })
     background_job_result.output = { errors: [title: error_title, detail: error_detail] }
     background_job_result.complete!
   end

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe IngestJob do
                              message: ' ()'] }.with_indifferent_access)
       expect(ActiveStorage::PurgeJob).to have_received(:perform_later).with(blob)
       expect(Honeybadger).to have_received(:notify).with('All retries failed',
-                                                         { external_identifier: 'druid:bc123dh5678' })
+                                                         context: { external_identifier: 'druid:bc123dh5678' })
     end
   end
 end

--- a/spec/jobs/update_job_spec.rb
+++ b/spec/jobs/update_job_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe UpdateJob do
 
       expect(actual_result).to be_complete
       expect(actual_result.output[:errors]).to eq [{ 'title' => err_title, 'detail' => err_detail }]
-      expect(Honeybadger).to have_received(:notify).with("#{err_title}: #{err_detail}", {
+      expect(Honeybadger).to have_received(:notify).with("#{err_title}: #{err_detail}", context: {
                                                            existing_version: 3,
                                                            external_identifier: 'druid:bc123dg5678',
                                                            provided_version: 5


### PR DESCRIPTION
## Why was this change made? 🤔
So that the context is correctly provided to HB.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



