### PR TITLE
Fix check for workflow existence

### DIFF
--- a/app/services/workflow.rb
+++ b/app/services/workflow.rb
@@ -15,10 +15,7 @@ class Workflow
   end
 
   def self.exists?(druid, workflow_name)
-    Dor::Services::Client.object(druid).workflow(workflow_name).find
-    true
-  rescue Dor::Services::Client::NotFoundResponse
-    false
+    Dor::Services::Client.object(druid).workflow(workflow_name).find.present?
   end
   private_class_method :exists?
 end

--- a/spec/services/workflow_spec.rb
+++ b/spec/services/workflow_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Workflow do
   let(:object_client) { instance_double(Dor::Services::Client::Object, workflow: workflow_client) }
-  let(:workflow_client) { instance_double(Dor::Services::Client::ObjectWorkflow, create: true, find: instance_double(Dor::Services::Response::Workflow)) }
+  let(:workflow_client) { instance_double(Dor::Services::Client::ObjectWorkflow, create: true, find: workflow_response) }
+  let(:workflow_response) { instance_double(Dor::Services::Response::Workflow, present?: workflow_present) }
+  let(:workflow_present) { true }
 
   let(:druid) { 'druid:bc123df4567' }
 
@@ -25,9 +27,7 @@ RSpec.describe Workflow do
     end
 
     context 'when the workflow does not exist' do
-      before do
-        allow(workflow_client).to receive(:find).and_raise(Dor::Services::Client::NotFoundResponse)
-      end
+      let(:workflow_present) { false }
 
       it 'creates a new workflow' do
         described_class.create_unless_exists(druid, 'accessionWF', version: 2, priority: 'low')


### PR DESCRIPTION
.

refs https://github.com/sul-dlss/hungry-hungry-hippo/issues/1751

## Why was this change made? 🤔
registrationWF was not being created because the check to see if a workflow exists was incorrect.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



