### PR TITLE
Sets lane_id when closing version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.1)
-    dor-services-client (15.40.0)
+    dor-services-client (15.41.0)
       activesupport (>= 7.0.0)
       cocina-models (~> 0.116.0)
       deprecation

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -14,7 +14,7 @@ class IngestJob < ApplicationJob
   # @param [Boolean] accession if true, closes the current version
   # @param [Boolean] assign_doi if true, adds DOI to Cocina obj
   # @param [String] priority ('default') determines the relative priority used for the workflow.
-  #                                      Value may be 'low' or 'default'
+  #                                      Value may be 'low', 'high', or 'default'
   # @param [String] user_versions ('none') - create, update, or do nothing with user versions on close.
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
@@ -56,7 +56,7 @@ class IngestJob < ApplicationJob
 
     # Close the version, which will also start accessioning
     # close will be false in the case of reserving a druid
-    Dor::Services::Client.object(druid).version.close(user_versions:) if accession
+    Dor::Services::Client.object(druid).version.close(user_versions:, lane_id: priority) if accession
     background_job_result.complete!
   rescue StandardError => e
     # This causes Sidekiq to retry.

--- a/openapi.yml
+++ b/openapi.yml
@@ -138,6 +138,7 @@ paths:
             enum:
               - "default"
               - "low"
+              - "high"
         - in: query
           name: assign_doi
           schema:

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe IngestJob do
       it 'ingests an object' do
         expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
         expect(Workflow).to have_received(:create_unless_exists).with(druid, 'registrationWF', version: 1, priority:)
-        expect(version_client).to have_received(:close).with(user_versions: 'none')
+        expect(version_client).to have_received(:close).with(user_versions: 'none', lane_id: 'default')
         expect(actual_result).to be_complete
         expect(actual_result.output).to match({ druid: })
         expect(ActiveStorage::PurgeJob).to have_received(:perform_later).with(blob)
@@ -93,7 +93,7 @@ RSpec.describe IngestJob do
       let(:user_versions) { 'new' }
 
       it 'ingests an object' do
-        expect(version_client).to have_received(:close).with(user_versions: 'new')
+        expect(version_client).to have_received(:close).with(user_versions: 'new', lane_id: 'default')
         expect(actual_result).to be_complete
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe IngestJob do
 
   context 'when files are on globus' do
     let(:objects_client) { instance_double(Dor::Services::Client::Objects, register: response_dro) }
-    let(:priority) { 'default' }
+    let(:priority) { 'high' }
     let(:globus_ids) do
       { 'file2.txt' => 'globus://some/file/path/file2.txt' }
     end
@@ -116,7 +116,7 @@ RSpec.describe IngestJob do
     it 'ingests an object' do
       expect(File.read("#{assembly_dir}/content/file2.txt")).to eq 'HELLO'
       expect(Workflow).to have_received(:create_unless_exists).with(druid, 'registrationWF', version: 1, priority:)
-      expect(version_client).to have_received(:close)
+      expect(version_client).to have_received(:close).with(user_versions: 'none', lane_id: 'high')
       expect(actual_result).to be_complete
       expect(actual_result.output).to match({ druid: })
     end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/5973

## Why was this change made? 🤔
So that the lane_id is correctly passed to DSA.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** (e.g. create_object_h2_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



