### PR TITLE
Bump cocina-models to 0.127.0 and DSC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.126.0)
+    cocina-models (0.127.0)
       activesupport
       cocina_display
       deprecation
@@ -157,9 +157,9 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.1)
-    dor-services-client (15.51.0)
+    dor-services-client (15.61.0)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.126.0)
+      cocina-models (~> 0.127.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry


### PR DESCRIPTION
## Why was this change made? 🤔
Keep cocina-models in sync



